### PR TITLE
Add entity event hook

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyrite_framework"
-version = "0.10.2"
+version = "0.11.0"
 authors = [
     { name="BetterBuiltFool", email="betterbuiltfool@gmail.com"}
 ]

--- a/src/pyrite/_data_classes/entity_manager.py
+++ b/src/pyrite/_data_classes/entity_manager.py
@@ -10,6 +10,8 @@ from ..types.entity import Entity
 if TYPE_CHECKING:
     from ..types._base_type import _BaseType
 
+import pygame
+
 
 class EntityManager(ABC):
 
@@ -75,6 +77,15 @@ class EntityManager(ABC):
         """
         pass
 
+    @abstractmethod
+    def handle_event(self, event: pygame.Event):
+        """
+        Passes the event down to all active entities.
+
+        :param event: A pygame event.
+        """
+        pass
+
     # Profiling methods
 
     @abstractmethod
@@ -134,6 +145,10 @@ class DefaultEntityManager(EntityManager):
     def const_update(self, timestep: float):
         for entity in self.entities:
             entity.const_update(timestep)
+
+    def handle_event(self, event: pygame.Event):
+        for entity in self.entities:
+            entity.on_event(event)
 
     def get_number_entities(self) -> int:
         return len(self.entities)

--- a/src/pyrite/game.py
+++ b/src/pyrite/game.py
@@ -313,7 +313,7 @@ class Game:
     def process_events(self, events: list[pygame.Event]) -> None:
         """
         Takes the list of events generated, and processes them.
-        by default, the events are passed on to handle_event.
+        by default, the events are passed on to handle_event and the entity manager.
         Pygame.QUIT is specifically checked.
 
         :param events: List of events since last frame.
@@ -321,6 +321,8 @@ class Game:
         for event in events:
             if event.type == pygame.QUIT:
                 self.quit_called()
+
+            self.entity_manager.handle_event(event)
             self.handle_event(event)
 
     def handle_event(self, event: pygame.Event) -> None:

--- a/src/pyrite/types/entity.py
+++ b/src/pyrite/types/entity.py
@@ -1,5 +1,7 @@
 from ._base_type import _BaseType
 
+import pygame
+
 
 class Entity(_BaseType):
     """
@@ -45,5 +47,14 @@ class Entity(_BaseType):
         depending on timestep length.
 
         :param timestep: Length of the timestep being simulated.
+        """
+        pass
+
+    def on_event(self, event: pygame.Event):
+        """
+        An event hook. Events will be passed to the entity when it's enabled, and can
+        be handled here.
+
+        :param event: A pygame event.
         """
         pass


### PR DESCRIPTION
Gives the entity class an event hook, so entities can respond to events by default.