### PR TITLE
Ensures pygame.typing only reference by typecheck

### DIFF
--- a/src/pyrite/types/camera.py
+++ b/src/pyrite/types/camera.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from collections.abc import Iterable, Sequence
 from typing import TYPE_CHECKING
 
-from pygame.typing import Point
 
 from .enums import Layer, RenderLayers
 from .entity import Entity
@@ -15,6 +14,7 @@ from pygame import Vector2
 
 if TYPE_CHECKING:
     from . import Container, HasPosition
+    from pygame.typing import Point
 
 
 class CameraBase:
@@ -55,7 +55,7 @@ class CameraBase:
     def _in_view(self, rect: pygame.Rect) -> bool:
         return self.surface.get_rect().colliderect(rect)
 
-    def to_local(self, point: pygame.typing.Point) -> Vector2:
+    def to_local(self, point: Point) -> Vector2:
         """
         Converts a point in world space to local space (The camera'ssurface)
 
@@ -64,7 +64,7 @@ class CameraBase:
         """
         return Vector2(point)
 
-    def to_world(self, point: pygame.typing.Point) -> Vector2:
+    def to_world(self, point: Point) -> Vector2:
         """
         Converts a point in local space (The camera's surface) to world space.
 
@@ -92,8 +92,8 @@ class Camera(CameraBase, Renderable):
 
     def __init__(
         self,
-        max_size: pygame.typing.Point,
-        position: pygame.typing.Point = None,
+        max_size: Point,
+        position: Point = None,
         surface_sectors: SurfaceSector | Sequence[SurfaceSector] = None,
         viewport: pygame.Rect = None,
         layer_mask: tuple[Layer] = None,
@@ -183,12 +183,12 @@ class Camera(CameraBase, Renderable):
     def render(self, delta_time: float) -> pygame.Surface:
         return self.surface.subsurface(self.viewport)
 
-    def to_local(self, point: pygame.typing.Point) -> Vector2:
+    def to_local(self, point: Point) -> Vector2:
         point = Vector2(point)
 
         return point - Vector2(self.get_surface_rect().topleft)
 
-    def to_world(self, point: pygame.typing.Point) -> Vector2:
+    def to_world(self, point: Point) -> Vector2:
         point = Vector2(point)
 
         return point + Vector2(self.get_surface_rect().topleft)
@@ -311,8 +311,8 @@ class ChaseCamera(Camera, Entity):
 
     def __init__(
         self,
-        max_size: pygame.typing.Point,
-        position: pygame.typing.Point = None,
+        max_size: Point,
+        position: Point = None,
         container=None,
         surface_sectors: SurfaceSector | Sequence[SurfaceSector] = None,
         enabled=True,

--- a/src/pyrite/utils/performance/dazzler.py
+++ b/src/pyrite/utils/performance/dazzler.py
@@ -13,7 +13,7 @@ from pygame import Surface, Rect
 
 if TYPE_CHECKING:
     from ...types import Container
-    from pygame.typing import Point
+    from pygame.typing import Point, RectLike
 
 
 class Dazzler(Entity, Renderable):
@@ -62,7 +62,7 @@ class Dazzler(Entity, Renderable):
         return self.surface
 
     @staticmethod
-    def multispawn(number_spawns, area: pygame.typing.RectLike) -> set[Dazzler]:
+    def multispawn(number_spawns, area: RectLike) -> set[Dazzler]:
         """
         Creates a number of Dazzlers randomly distributed within a rectangular area.
 


### PR DESCRIPTION
Eliminates and runtime checking of the pygame.typing module, which doesn't work with pygbag apparently