### PR TITLE
Rename static decor

### DIFF
--- a/src/pyrite/types/__init__.py
+++ b/src/pyrite/types/__init__.py
@@ -6,6 +6,8 @@ from .camera import CameraBase, Camera, ChaseCamera  # noqa: F401
 from .entity import Entity  # noqa: F401
 from .enums import RenderLayers, AnchorPoint, Layer, Anchor  # noqa: F401
 from .renderable import Renderable  # noqa: F401
+from .sprite import Sprite  # noqa: F401
+from .spritesheet import SpriteSheet, SpriteMap  # noqa: F401
 from .surface_sector import SurfaceSector  # noqa: F401
 from .static_decor import StaticDecor  # noqa: F401
 

--- a/src/pyrite/types/sprite.py
+++ b/src/pyrite/types/sprite.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import typing
+
+import pygame
+
+
+if typing.TYPE_CHECKING:
+    from . import Container
+    from .enums import Layer, Anchor
+    from pygame import Surface, Rect
+    from pygame.typing import Point
+
+
+from .renderable import Renderable
+from .enums import AnchorPoint
+
+
+class sprite(Renderable):
+    """
+    A basic renderable with a world position and a surface to display.
+    """
+
+    def __init__(
+        self,
+        display_surface: Surface,
+        position: Point = (0, 0),
+        anchor: Anchor = AnchorPoint.CENTER,
+        container: Container = None,
+        enabled=True,
+        layer: Layer = None,
+        draw_index=0,
+    ) -> None:
+        """
+        A basic renderable that displays a surface at a world position.
+
+        :param display_surface: The image or surface to be shown.
+        :param position: Location of the Decor object, in world space,
+        defaults to (0, 0)
+        :param anchor: AnchorPoint that determines where on the object the position
+        references, defaults to Anchor.CENTER
+        :param container: Container object for the renderable, defaults to None
+        :param enabled: Whether or not the object should be active immediately upon
+        spawn, defaults to True
+        :param layer: Render layer to which the object belongs, defaults to None
+        :param draw_index: Draw order for the renderable, defaults to 0
+        """
+        super().__init__(container, enabled, layer, draw_index)
+        self.display_surface = display_surface
+        self.position = pygame.Vector2(position)
+        self.anchor = anchor
+
+    def get_rect(self) -> Rect:
+        rect = self.display_surface.get_rect()
+        self.anchor.anchor_rect_ip(rect, self.position)
+        return rect
+
+    def render(self, delta_time: float) -> pygame.Surface:
+        return self.display_surface

--- a/src/pyrite/types/sprite.py
+++ b/src/pyrite/types/sprite.py
@@ -16,7 +16,7 @@ from .renderable import Renderable
 from .enums import AnchorPoint
 
 
-class sprite(Renderable):
+class Sprite(Renderable):
     """
     A basic renderable with a world position and a surface to display.
     """

--- a/src/pyrite/types/static_decor.py
+++ b/src/pyrite/types/static_decor.py
@@ -16,6 +16,17 @@ if typing.TYPE_CHECKING:
 from .renderable import Renderable
 from .enums import AnchorPoint
 
+first_creation = True
+
+
+def warn_deprecated():
+    if first_creation:
+        warnings.warn(
+            "StaticDecor is deprecated. Use Sprite instead.", DeprecationWarning
+        )
+        global first_creation
+        first_creation = False
+
 
 class StaticDecor(Renderable):
     """
@@ -51,9 +62,7 @@ class StaticDecor(Renderable):
         :param layer: Render layer to which the object belongs, defaults to None
         :param draw_index: Draw order for the renderable, defaults to 0
         """
-        warnings.warn(
-            "StaticDecor is deprecated. Use Sprite instead.", DeprecationWarning
-        )
+        warn_deprecated()
         super().__init__(container, enabled, layer, draw_index)
         self.display_surface = display_surface
         self.position = pygame.Vector2(position)

--- a/src/pyrite/types/static_decor.py
+++ b/src/pyrite/types/static_decor.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import typing
+import warnings
 
 import pygame
 
@@ -18,6 +19,8 @@ from .enums import AnchorPoint
 
 class StaticDecor(Renderable):
     """
+    DEPRECATED
+
     A basic renderable with a world position and a surface to display.
     Has no behavior, just renders.
     """
@@ -33,6 +36,8 @@ class StaticDecor(Renderable):
         draw_index=0,
     ) -> None:
         """
+        DEPRECATED
+
         A Decor object with no behavior. Renders a surface based on its position.
 
         :param display_surface: The image or surface to be shown.
@@ -46,6 +51,9 @@ class StaticDecor(Renderable):
         :param layer: Render layer to which the object belongs, defaults to None
         :param draw_index: Draw order for the renderable, defaults to 0
         """
+        warnings.warn(
+            "StaticDecor is deprecated. Use Sprite instead.", DeprecationWarning
+        )
         super().__init__(container, enabled, layer, draw_index)
         self.display_surface = display_surface
         self.position = pygame.Vector2(position)


### PR DESCRIPTION
Adds a copy of StaticDecor named as Sprite, which is more indicative of the job of the class.

StaticDecor is still available, but it is marked as deprecated. If Pyrite is updated to 3.13+, this needs to be modified to make use of the deprecated decorator, although Staticdecor will likely be removed from that version.