### PR TITLE
Refactor sprite sheet

### DIFF
--- a/src/pyrite/types/sprite.py
+++ b/src/pyrite/types/sprite.py
@@ -46,6 +46,7 @@ class Sprite(Renderable):
         :param draw_index: Draw order for the renderable, defaults to 0
         """
         super().__init__(container, enabled, layer, draw_index)
+        self._reference_image = display_surface
         self.display_surface = display_surface
         self.position = pygame.Vector2(position)
         self.anchor = anchor
@@ -76,7 +77,14 @@ class Sprite(Renderable):
 
         self.flip_x, self.flip_y = flip_x, flip_y
 
-        new_surface = pygame.transform.flip(sprite_image, flip_x, flip_y)
+        self._reference_image = pygame.transform.flip(sprite_image, flip_x, flip_y)
+
+        self._force_update_surface()
+
+    def _force_update_surface(self):
+        new_surface = pygame.transform.flip(
+            self._reference_image, self.flip_x, self.flip_y
+        )
 
         self.display_surface = new_surface
 

--- a/src/pyrite/types/sprite.py
+++ b/src/pyrite/types/sprite.py
@@ -60,6 +60,16 @@ class Sprite(Renderable):
     def flip_y(self):
         return self._flip_y
 
+    def set_sprite(self, sprite_image: Surface, flip_x=None, flip_y=None):
+        flip_x = flip_x if flip_x is not None else self.flip_x
+        flip_y = flip_y if flip_y is not None else self.flip_y
+
+        self.flip_x, self.flip_y = flip_x, flip_y
+
+        new_surface = pygame.transform.flip(sprite_image, flip_x, flip_y)
+
+        self.display_surface = new_surface
+
     def get_rect(self) -> Rect:
         rect = self.display_surface.get_rect()
         self.anchor.anchor_rect_ip(rect, self.position)

--- a/src/pyrite/types/sprite.py
+++ b/src/pyrite/types/sprite.py
@@ -49,6 +49,16 @@ class Sprite(Renderable):
         self.display_surface = display_surface
         self.position = pygame.Vector2(position)
         self.anchor = anchor
+        self._flip_x = False
+        self._flip_y = False
+
+    @property
+    def flip_x(self):
+        return self._flip_x
+
+    @property
+    def flip_y(self):
+        return self._flip_y
 
     def get_rect(self) -> Rect:
         rect = self.display_surface.get_rect()

--- a/src/pyrite/types/sprite.py
+++ b/src/pyrite/types/sprite.py
@@ -57,18 +57,40 @@ class Sprite(Renderable):
 
     @property
     def flip_x(self) -> bool:
+        """
+        Shows if the image is set to be flipped along the x axis.
+        """
         return self._flip_x
 
     @flip_x.setter
     def flip_x(self, flag: bool):
+        """
+        Sets the sprite to be flipped along the x axis.
+        Note: setting this directly will not automatically flip the display. Use
+        set_surface() for that, or call _force_update_surface() after setting the flip
+        parameters.
+
+        :param flag: Boolean determining whether to flip the sprite image.
+        """
         self._flip_x = flag
 
     @property
     def flip_y(self) -> bool:
+        """
+        Shows if the image is set to be flipped along the y axis.
+        """
         return self._flip_y
 
     @flip_y.setter
     def flip_y(self, flag: bool):
+        """
+        Sets the sprite to be flipped along the y axis.
+        Note: setting this directly will not automatically flip the display. Use
+        set_surface() for that, or call _force_update_surface() after setting the flip
+        parameters.
+
+        :param flag: Boolean determining whether to flip the sprite image.
+        """
         self.flip_y = flag
 
     def set_surface(self, sprite_image: Surface, flip_x=None, flip_y=None):

--- a/src/pyrite/types/sprite.py
+++ b/src/pyrite/types/sprite.py
@@ -93,13 +93,26 @@ class Sprite(Renderable):
         """
         self.flip_y = flag
 
-    def set_surface(self, sprite_image: Surface, flip_x=None, flip_y=None):
+    def set_surface(
+        self, sprite_image: Surface = None, flip_x: bool = None, flip_y: bool = None
+    ):
+        """
+        Changes the sprite's display to match the given properties.
+        If any parameter is None, it uses the sprite's current setting.
+
+        :param sprite_image: The raw surface being used, defaults to None
+        :param flip_x: Whether to flip along the x axis, defaults to None
+        :param flip_y: Whether to flip along the y axis, defaults to None
+        """
+        sprite_image = (
+            sprite_image if sprite_image is not None else self._reference_image
+        )
         flip_x = flip_x if flip_x is not None else self.flip_x
         flip_y = flip_y if flip_y is not None else self.flip_y
 
         self.flip_x, self.flip_y = flip_x, flip_y
 
-        self._reference_image = pygame.transform.flip(sprite_image, flip_x, flip_y)
+        self._reference_image = sprite_image
 
         self._force_update_surface()
 

--- a/src/pyrite/types/sprite.py
+++ b/src/pyrite/types/sprite.py
@@ -91,7 +91,7 @@ class Sprite(Renderable):
 
         :param flag: Boolean determining whether to flip the sprite image.
         """
-        self.flip_y = flag
+        self._flip_y = flag
 
     def set_surface(
         self, sprite_image: Surface = None, flip_x: bool = None, flip_y: bool = None

--- a/src/pyrite/types/sprite.py
+++ b/src/pyrite/types/sprite.py
@@ -49,18 +49,28 @@ class Sprite(Renderable):
         self.display_surface = display_surface
         self.position = pygame.Vector2(position)
         self.anchor = anchor
+
+        # Clients can update these easily enough.
         self._flip_x = False
         self._flip_y = False
 
     @property
-    def flip_x(self):
+    def flip_x(self) -> bool:
         return self._flip_x
 
+    @flip_x.setter
+    def flip_x(self, flag: bool):
+        self._flip_x = flag
+
     @property
-    def flip_y(self):
+    def flip_y(self) -> bool:
         return self._flip_y
 
-    def set_sprite(self, sprite_image: Surface, flip_x=None, flip_y=None):
+    @flip_y.setter
+    def flip_y(self, flag: bool):
+        self.flip_y = flag
+
+    def set_surface(self, sprite_image: Surface, flip_x=None, flip_y=None):
         flip_x = flip_x if flip_x is not None else self.flip_x
         flip_y = flip_y if flip_y is not None else self.flip_y
 

--- a/src/pyrite/types/spritesheet.py
+++ b/src/pyrite/types/spritesheet.py
@@ -245,8 +245,6 @@ class SpriteSheet:
         self._reference_sprite = reference_sprite
         self.sprite_map = sprite_map
 
-        self.surface: Surface = None
-
         self._sprite_key = start_state
 
     @property
@@ -258,33 +256,36 @@ class SpriteSheet:
         """
         return self._sprite_key
 
-    def get_sprite(self, sprite_key: Any = None):
+    def get_sprite(self, sprite_key: Any = None) -> Surface | None:
         """
-        Updates the attributes of the spritesheet that determine the surface to be
-        drawn.
+        Gets the sprite image that matches the given key, updating the stored key.
+        Returns the sprite image that matches the key.
 
-        Then, updates the surface to reflect these new values.
+        If no key is supplied, returns the image that matches the current key.
 
-        If a parameter is None, it will use the current value stored by the spritesheet.
+        If no surface is available, returns None.
 
-        :param sprite_key: The key used to determine the subrect, defaults to None
-        :param flip_x: Whether to flip along the x axis, defaults to None
-        :param flip_y: Whether to flip along th y axis, defaults to None
+        :param sprite_key: The key used to determine the subrect of the desired sprite
+        image, defaults to None
+        :return: The subsurface matching the sprite key, or None if the key is not
+        valid.
         """
+        sprite_key = sprite_key if sprite_key is not None else self._sprite_key
         self._sprite_key = sprite_key
-        self.surface = self.get_subsurface(sprite_key)
-        return self.surface
+        return self.get_subsurface(sprite_key)
 
-    def get_subsurface(self, sprite_key: Any) -> Surface:
+    def get_subsurface(self, sprite_key: Any = None) -> Surface | None:
         """
         Gets a subsurface of the reference sheet based on the supplied sprite_key.
+        Does not change the state of the sprite sheet.
 
         If the key is invalid, returns the current surface.
 
         :param sprite_key: Key value appropriate for the spritesheet's SpriteMap
-        :return: The subsurface matching the sprite key.
+        :return: The subsurface matching the sprite key, or None if the key is not
+        valid.
         """
         rect = self.sprite_map.get(sprite_key)
         if rect is None:
-            return self.surface
+            return None
         return self._reference_sprite.subsurface(rect)

--- a/src/pyrite/types/spritesheet.py
+++ b/src/pyrite/types/spritesheet.py
@@ -218,8 +218,7 @@ class DictSpriteMap(SpriteMap):
 
 class SpriteSheet:
     """
-    TODO Update docs
-    A renderable that can display subsections of a larger surface.
+    A tool that can select subsections of a larger surface for display.
     Useful for animations, or otherwise collecting multiple images
     into one larger surface.
 
@@ -233,7 +232,7 @@ class SpriteSheet:
         start_state: Any = None,
     ) -> None:
         """
-        Creates a new Spritesheet renderable.
+        Creates a new Spritesheet.
 
         :param reference_sprite: The reference surface containing all of the subsurfaces
         needed. As a reference, can be shared by multiple sprite sheets.

--- a/tests/test_spritesheet.py
+++ b/tests/test_spritesheet.py
@@ -52,9 +52,8 @@ class TestSpriteSheet(unittest.TestCase):
 
         invalid_key = None
 
-        self.assertIs(
-            # invalid key should cause the current surface to be returned.
-            self.spritesheet.surface,
+        self.assertIsNone(
+            # invalid key should cause None to be returned.
             self.spritesheet.get_subsurface(invalid_key),
         )
 

--- a/tests/test_spritesheet.py
+++ b/tests/test_spritesheet.py
@@ -6,7 +6,6 @@ import pygame
 
 
 sys.path.append(str(pathlib.Path.cwd()))
-from src.pyrite.types._base_type import _BaseType  # noqa:E402
 from src.pyrite.types.spritesheet import (  # noqa:E402
     SimpleSpriteMap,
     SpriteSheet,
@@ -32,73 +31,11 @@ class TestSpriteMap(SimpleSpriteMap):
         return self._map[row][column]
 
 
-class MockGame:
-
-    def __init__(self) -> None:
-        self.items = set()
-
-    def enable(self, item: _BaseType):
-        self.items.add(item)
-
-    def disable(self, item: _BaseType):
-        self.items.discard(item)
-
-
 class TestSpriteSheet(unittest.TestCase):
 
     def setUp(self) -> None:
-        game = MockGame()
         sprite_map = TestSpriteMap(8, 8, (8, 8))
-        self.spritesheet = SpriteSheet(
-            test_image, sprite_map, start_state=(0, 0), container=game
-        )
-
-    def test_validate_state(self):
-
-        # Case All params used, changing flip values
-
-        self.assertEqual(
-            ((0, 0), True, True), self.spritesheet._validate_state((0, 0), True, True)
-        )
-
-        # Case All params used, matching existing flip values
-
-        self.assertEqual(
-            ((0, 0), False, False),
-            self.spritesheet._validate_state((0, 0), False, False),
-        )
-
-        # Case Default flip params
-
-        self.assertEqual(
-            ((0, 0), False, False),
-            self.spritesheet._validate_state((0, 0), None, None),
-        )
-
-        # Case Default flip params with different current value
-
-        self.spritesheet._flip_x = True
-
-        self.assertEqual(
-            ((0, 0), True, False),
-            self.spritesheet._validate_state((0, 0), None, None),
-        )
-
-        self.spritesheet._flip_x = False
-
-        # Case Default state key param
-
-        self.assertEqual(
-            ((0, 0), False, False),
-            self.spritesheet._validate_state(None, False, False),
-        )
-
-        # Case match, no params used
-
-        self.assertEqual(
-            ((0, 0), False, False),
-            self.spritesheet._validate_state(None, None, None),
-        )
+        self.spritesheet = SpriteSheet(test_image, sprite_map, start_state=(0, 0))
 
     def test_get_subsurface(self):
         key = (1, 1)


### PR DESCRIPTION
Changes SpriteSheet from a renderable to a utility that supplies sprites to be used by the Sprite class.

Sprite has received many of the stateful aspects of SpriteSheet, such as managing the flipx/y aspects of the sprite, and maintains a reference_image attribute separate from display_surface. Reference_image should not be altered, but display_surface should be derived from it or equal to it.

Sprites should have their image set using the set_surface() method, which contains the opportunity to flip the image along either axis. Setting display_surface directly is possible but not generally recommended.