### PR TITLE
Make layer change force update

### DIFF
--- a/src/pyrite/core/entity_manager.py
+++ b/src/pyrite/core/entity_manager.py
@@ -132,13 +132,19 @@ class DefaultEntityManager(EntityManager):
 
     def enable(self, item: _BaseType) -> bool:
         if isinstance(item, Entity):
-            self._added_buffer.add(item)
+            if item in self._disabled_buffer:
+                self._disabled_buffer.remove(item)
+            else:
+                self._added_buffer.add(item)
             return item not in self.entities
         return False
 
     def disable(self, item: _BaseType) -> bool:
         if isinstance(item, Entity):
-            self._disabled_buffer.add(item)
+            if item in self._added_buffer:
+                self._added_buffer.remove(item)
+            else:
+                self._disabled_buffer.add(item)
             return item in self.entities
         return False
 

--- a/src/pyrite/core/renderer.py
+++ b/src/pyrite/core/renderer.py
@@ -143,7 +143,7 @@ class DefaultRenderManager(RenderManager):
         if layer is None:
             # No layer set, force it to midground
             layer = RenderLayers.MIDGROUND
-            item.layer = layer
+            item._layer = layer
         render_layer = self.renderables.setdefault(layer, WeakSet())
 
         # Check if this is a fresh enable

--- a/src/pyrite/types/renderable.py
+++ b/src/pyrite/types/renderable.py
@@ -4,12 +4,12 @@ from abc import abstractmethod, ABC
 from typing import TYPE_CHECKING
 
 from ._base_type import _BaseType
-from .enums import Layer
 
 import pygame
 
 if TYPE_CHECKING:
     from . import Container
+    from .enums import Layer
 
 
 class Renderable(_BaseType, ABC):
@@ -24,7 +24,7 @@ class Renderable(_BaseType, ABC):
         layer: Layer = None,
         draw_index=0,
     ) -> None:
-        self.layer: Layer = layer
+        self._layer: Layer = layer
         self.draw_index = draw_index
         """
         (The following is only true for default renderer; Others may vary)
@@ -34,6 +34,16 @@ class Renderable(_BaseType, ABC):
         Renderables in the same layer with the same index may be drawn in any order.
         """
         _BaseType.__init__(self, container, enabled)
+
+    @property
+    def layer(self) -> Layer:
+        return self._layer
+
+    @layer.setter
+    def layer(self, new_layer: Layer):
+        if self._layer is not new_layer:
+            pass
+        self._layer = new_layer
 
     @abstractmethod
     def render(self, delta_time: float) -> pygame.Surface:

--- a/src/pyrite/types/renderable.py
+++ b/src/pyrite/types/renderable.py
@@ -42,8 +42,13 @@ class Renderable(_BaseType, ABC):
     @layer.setter
     def layer(self, new_layer: Layer):
         if self._layer is not new_layer:
-            pass
-        self._layer = new_layer
+            enabled = self.enabled
+            # This allows us to update within the renderer without firing
+            # on enable/disable events.
+            self.container.disable(self)
+            self._layer = new_layer
+            if enabled:
+                self.container.enable(self)
 
     @abstractmethod
     def render(self, delta_time: float) -> pygame.Surface:

--- a/tests/test_entity_manager.py
+++ b/tests/test_entity_manager.py
@@ -24,7 +24,7 @@ class MockRenderable(Renderable):
     def __init__(
         self, game_instance=None, enabled=True, layer: Layer = None, draw_index=-1
     ) -> None:
-        self.layer = layer
+        self._layer = layer
         self.draw_index = draw_index
 
     def render(self, delta_time: float) -> tuple[Surface, Point | Rect]:

--- a/tests/test_render_manager.py
+++ b/tests/test_render_manager.py
@@ -27,7 +27,7 @@ class MockRenderable(Renderable):
     def __init__(
         self, game_instance=None, enabled=True, layer: Layer = None, draw_index=-1
     ) -> None:
-        self.layer = layer
+        self._layer = layer
         self.draw_index = draw_index
 
     def render(self, delta_time: float) -> tuple[Surface, Point | Rect]:


### PR DESCRIPTION
Changing the layer on a renderable now forces the render manager to update the object and put it in the new layer.