### PR TITLE
Update instance events

### DIFF
--- a/src/pyrite/types/instance_event.py
+++ b/src/pyrite/types/instance_event.py
@@ -96,25 +96,50 @@ class InstanceEvent(ABC):
 
         Example:
         ____________________________________________________________________________________________
-
+        ```
         class A:
 
             def __init__(self):
                 self.event_haver = SomeEntity()
 
+                # Does not have to be an attribute's event, can be any event.
                 @self.event_haver.OnSomeEvent.add_listener(self)
                 def _(self, event_param1, event_param2):
                     print(self)
                     # Do something
+        ```
         ____________________________________________________________________________________________
 
         Every instance of A will create its own listener, which can reference "self" to
         refer to that instance, while also allowing access to the event's
-        parameters.
+        parameters. Please not that any closures in the listener can tie those objects
+        to the lifetimes of the event and/or the caller.
 
-        Note: This method will remove strong references in any closures in the listener.
-        This means the listener function will not prevent the creating object from
-        being garbage collected.
+        Can also be used as a non-decorator on regular functions and bound methods.
+        This will create a hard reference to the object of the bound method, though,
+        and tie it to the lifetime of the event instance.
+
+        Example:
+        ____________________________________________________________________________________________
+        ```
+        class A:
+
+            def some_method(self, event_param1, event_param2):
+                print(self)
+                # Do something
+
+        foo = A()
+
+        some_event.add_listener(foo.some_method)
+        # Remember to pass the method, not call it
+
+        # Or:
+        def bar(event_param1, event_param2):
+            # Do something else
+
+        some_event.add_listener(bar)
+        ```
+        ____________________________________________________________________________________________
 
         :return: The original listener, to be available for reuse and access.
         """

--- a/src/pyrite/types/instance_event.py
+++ b/src/pyrite/types/instance_event.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from collections.abc import Callable
 from typing import Any, TypeVar
-from weakref import proxy, ref, WeakKeyDictionary, ProxyTypes
+from weakref import ref, WeakKeyDictionary
 
 # This is NOT the standard library threading module.
 from ..utils import threading
@@ -11,31 +11,6 @@ from ..utils import threading
 
 T = TypeVar("T")
 E = TypeVar("E", bound="InstanceEvent")
-
-
-def weaken_closures(listener: Callable) -> Callable:
-    """
-    Converts a callable's closures to proxies, so the callable doesn't prevent garbage
-    collection on the enclosed objects.
-
-    Makes no changes if the callable has no closures, or if the closures are already
-    proxied.
-
-    :return: The listener, without strong references.
-    """
-    if listener.__closure__ is None:
-        return listener
-
-    for cell in listener.__closure__:
-        contents = cell.cell_contents
-        # Instance checks are relatively slow, but we're only doing this occasionally.
-        # ...
-        # You are only doing this occasionally, right?
-        if isinstance(contents, ProxyTypes):
-            continue
-        cell.cell_contents = proxy(contents)
-
-    return listener
 
 
 class InstanceEvent(ABC):
@@ -137,7 +112,7 @@ class InstanceEvent(ABC):
         """
 
         def inner(listener: Callable):
-            self._register(caller, weaken_closures(listener))
+            self._register(caller, listener)
             return listener
 
         return inner

--- a/src/pyrite/types/instance_event.py
+++ b/src/pyrite/types/instance_event.py
@@ -136,22 +136,18 @@ class InstanceEvent(ABC):
 
     def _register(self, caller, listener: Callable):
         listeners = self.listeners.setdefault(caller, [])
-        # print(listener.__repr__.__self__)
         # TODO Test if method, keep methods and function in two different sets?
         listeners.append(listener)
-        # self.listeners.update({caller: listener})
 
     def _deregister(self, listener: Callable):
-        # to_remove = None
         for caller, listeners in self.listeners.items():
             if listener in listeners:
                 listeners.remove(listener)
+                # Note: if a listener managed to get in there multiple times,
+                # this will only remove one occurence.
+                # If that happens, though, something went horribly wrong.
+                # See you in 2 years!
                 break
-        #     if value is listener:
-        #         to_remove = key
-        #         break
-        # if to_remove:
-        #     self.listeners.pop(to_remove)
 
     def _notify(self, *args, **kwds):
         """

--- a/src/pyrite/types/instance_event.py
+++ b/src/pyrite/types/instance_event.py
@@ -146,7 +146,13 @@ class InstanceEvent(ABC):
         self.listeners.update({caller: listener})
 
     def _deregister(self, listener: Callable):
-        self.listeners.discard(listener)
+        to_remove = None
+        for key, value in self.listeners.items():
+            if value is listener:
+                to_remove = key
+                break
+        if to_remove:
+            self.listeners.pop(to_remove)
 
     def _notify(self, *args, **kwds):
         """

--- a/tests/test_instance_event.py
+++ b/tests/test_instance_event.py
@@ -50,8 +50,8 @@ class TestInstanceEvent(unittest.TestCase):
         self.test_object = TestObject()
 
     def tearDown(self) -> None:
-        self.test_object.OnTestEvent1.listeners = set()
-        self.test_object.OnTestEvent2.listeners = set()
+        self.test_object.OnTestEvent1.listeners = dict()
+        self.test_object.OnTestEvent2.listeners = dict()
 
     def test_register(self):
 
@@ -84,6 +84,38 @@ class TestInstanceEvent(unittest.TestCase):
             pass
 
         self.assertIn(test_dummy, self.test_object.OnTestEvent1.listeners.get(SENTINEL))
+
+        event1 = self.test_object.OnTestEvent1
+
+        class TestItem:
+            def __init__(self) -> None:
+                @event1.add_listener(self)
+                def _(self):
+                    pass
+
+        test_item = TestItem()
+
+        self.assertTrue(event1.listeners.get(test_item))
+
+        class TestItem2:
+
+            def test_method(self):
+                pass
+
+        test_item_2 = TestItem2()
+        test_item_3 = TestItem2()
+
+        event1.add_listener(test_item_2.test_method)
+
+        self.assertIn(
+            test_item_2.test_method,
+            self.test_object.OnTestEvent1.listeners.get(SENTINEL),
+            # Bound methods go under SENTINEL
+        )
+        self.assertNotIn(
+            test_item_3.test_method,
+            self.test_object.OnTestEvent1.listeners.get(SENTINEL),
+        )
 
     def test_notify(self):
 

--- a/tests/test_instance_event.py
+++ b/tests/test_instance_event.py
@@ -4,7 +4,7 @@ import unittest
 
 
 sys.path.append(str(pathlib.Path.cwd()))
-from src.pyrite.types.instance_event import InstanceEvent  # noqa:E402
+from src.pyrite.types.instance_event import InstanceEvent, SENTINEL  # noqa:E402
 from src.pyrite.utils import threading  # noqa:E402
 
 
@@ -58,22 +58,24 @@ class TestInstanceEvent(unittest.TestCase):
         def test_dummy():
             pass
 
-        self.test_object.OnTestEvent1._register(test_dummy)
+        self.test_object.OnTestEvent1._register(SENTINEL, test_dummy)
 
-        self.assertIn(test_dummy, self.test_object.OnTestEvent1.listeners)
+        self.assertIn(test_dummy, self.test_object.OnTestEvent1.listeners.get(SENTINEL))
 
     def test_deregister(self):
 
         def test_dummy():
             pass
 
-        self.test_object.OnTestEvent1._register(test_dummy)
+        self.test_object.OnTestEvent1._register(SENTINEL, test_dummy)
 
-        self.assertIn(test_dummy, self.test_object.OnTestEvent1.listeners)
+        self.assertIn(test_dummy, self.test_object.OnTestEvent1.listeners.get(SENTINEL))
 
         self.test_object.OnTestEvent1._deregister(test_dummy)
 
-        self.assertNotIn(test_dummy, self.test_object.OnTestEvent1.listeners)
+        self.assertNotIn(
+            test_dummy, self.test_object.OnTestEvent1.listeners.get(SENTINEL)
+        )
 
     def test_add_listener(self):
 
@@ -81,7 +83,7 @@ class TestInstanceEvent(unittest.TestCase):
         def test_dummy(param1: bool):
             pass
 
-        self.assertIn(test_dummy, self.test_object.OnTestEvent1.listeners)
+        self.assertIn(test_dummy, self.test_object.OnTestEvent1.listeners.get(SENTINEL))
 
     def test_notify(self):
 


### PR DESCRIPTION
Changes the syntax for add_listener.

For anonymous functions defined during an object's initialization, they can take an additional argument, almost always will be the instance being initialized. This will be passed into the anonymous function as if it were a method, and will bind the function to that object so as not interfere with garbage collection.

Alternatively, it can be used without that argument, either as a standard call or as a decorator, on regular function or a static method. This will call that function/method normally.

Thirdly, it can be used as a standard call on an instance's bound method, allowing for a late binding of a method. The caveat is that this will tie the lifespan of that instance to the event.