### PR TITLE
Add manager getters

### DIFF
--- a/src/pyrite/__init__.py
+++ b/src/pyrite/__init__.py
@@ -6,7 +6,6 @@ from .core.rate_settings import RateSettings  # noqa:F401
 from .game import (  # noqa:F401
     Game,
     AsyncGame,
-    get_system_manager,
     get_game_instance,
 )
 

--- a/src/pyrite/__init__.py
+++ b/src/pyrite/__init__.py
@@ -8,7 +8,6 @@ from .game import (  # noqa:F401
     AsyncGame,
     get_system_manager,
     get_game_instance,
-    get_entity_manager,
 )
 
 from .camera import Camera, ChaseCamera  # noqa:F401

--- a/src/pyrite/__init__.py
+++ b/src/pyrite/__init__.py
@@ -3,7 +3,6 @@ import pygame
 from .core.display_settings import DisplaySettings
 from .core.game_data import GameData  # noqa:F401
 from .core.rate_settings import RateSettings  # noqa:F401
-from .core.renderer import get_render_manager, get_renderer  # noqa:F401
 from .game import (  # noqa:F401
     Game,
     AsyncGame,

--- a/src/pyrite/__init__.py
+++ b/src/pyrite/__init__.py
@@ -3,14 +3,13 @@ import pygame
 from .core.display_settings import DisplaySettings
 from .core.game_data import GameData  # noqa:F401
 from .core.rate_settings import RateSettings  # noqa:F401
+from .core.renderer import get_render_manager, get_renderer  # noqa:F401
 from .game import (  # noqa:F401
     Game,
     AsyncGame,
     get_system_manager,
     get_game_instance,
     get_entity_manager,
-    get_render_manager,
-    get_renderer,
 )
 
 from .camera import Camera, ChaseCamera  # noqa:F401

--- a/src/pyrite/core/entity_manager.py
+++ b/src/pyrite/core/entity_manager.py
@@ -29,6 +29,12 @@ _deferred_enables: set[Entity] = set()
 
 
 def enable(entity: Entity):
+    """
+    Enables an entity with the active entity manager.
+    If no active entity manager exists, the entity is stored until one is created.
+
+    :param entity: An entity to be enabled.
+    """
     if _active_entity_manager:
         _active_entity_manager.enable(entity)
         return
@@ -36,6 +42,13 @@ def enable(entity: Entity):
 
 
 def disable(entity: Entity):
+    """
+    Disables an entity in the active entity manager,
+    If no active entity manager exists and the entity is queued for enabling,
+    it is removed from the queue.
+
+    :param entity: An entity to be disabled.
+    """
     if _active_entity_manager:
         _active_entity_manager.disable(entity)
         return

--- a/src/pyrite/core/entity_manager.py
+++ b/src/pyrite/core/entity_manager.py
@@ -28,18 +28,18 @@ def set_entity_manager(manager: EntityManager):
 _deferred_enables: set[Entity] = set()
 
 
-def enable(system: Entity):
+def enable(entity: Entity):
     if _active_entity_manager:
-        _active_entity_manager.enable(system)
+        _active_entity_manager.enable(entity)
         return
-    _deferred_enables.add(system)
+    _deferred_enables.add(entity)
 
 
-def disable(system: Entity):
+def disable(entity: Entity):
     if _active_entity_manager:
-        _active_entity_manager.disable(system)
+        _active_entity_manager.disable(entity)
         return
-    _deferred_enables.discard(system)
+    _deferred_enables.discard(entity)
 
 
 class EntityManager(ABC):

--- a/src/pyrite/core/entity_manager.py
+++ b/src/pyrite/core/entity_manager.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING
+from typing import Self, TYPE_CHECKING
 
 from weakref import WeakSet
 
@@ -13,7 +13,24 @@ if TYPE_CHECKING:
 import pygame
 
 
+_active_entity_manager: EntityManager = None
+
+
+def get_entity_manager() -> EntityManager:
+    return _active_entity_manager
+
+
+def set_entity_manager(manager: EntityManager):
+    global _active_entity_manager
+    _active_entity_manager = manager
+
+
 class EntityManager(ABC):
+
+    def __new__(cls) -> Self:
+        new_manager = super().__new__(cls)
+        set_entity_manager(new_manager)
+        return new_manager
 
     @abstractmethod
     def enable(self, item: _BaseType) -> bool:

--- a/src/pyrite/core/renderer.py
+++ b/src/pyrite/core/renderer.py
@@ -21,28 +21,28 @@ if TYPE_CHECKING:
 import pygame
 
 
-active_render_manager: RenderManager = None
+_active_render_manager: RenderManager = None
 
 
 def get_render_manager() -> RenderManager:
-    return active_render_manager
+    return _active_render_manager
 
 
 def set_render_manager(manager: RenderManager):
-    global active_render_manager
-    active_render_manager = manager
+    global _active_render_manager
+    _active_render_manager = manager
 
 
-active_renderer: Renderer = None
+_active_renderer: Renderer = None
 
 
 def get_renderer() -> Renderer:
-    return active_renderer
+    return _active_renderer
 
 
 def set_renderer(renderer: Renderer):
-    global active_renderer
-    active_renderer = renderer
+    global _active_renderer
+    _active_renderer = renderer
 
 
 class RenderManager(ABC):

--- a/src/pyrite/core/renderer.py
+++ b/src/pyrite/core/renderer.py
@@ -33,6 +33,18 @@ def set_render_manager(manager: RenderManager):
     active_render_manager = manager
 
 
+active_renderer: Renderer = None
+
+
+def get_renderer() -> Renderer:
+    return active_renderer
+
+
+def set_renderer(renderer: Renderer):
+    global active_renderer
+    active_renderer = renderer
+
+
 class RenderManager(ABC):
     """
     An object for managing renderables. Can enable and disable them, and generates a

--- a/src/pyrite/core/renderer.py
+++ b/src/pyrite/core/renderer.py
@@ -21,10 +21,10 @@ if TYPE_CHECKING:
 import pygame
 
 
-active_render_manager: Renderer = None
+active_render_manager: RenderManager = None
 
 
-def get_render_manager() -> Renderer:
+def get_render_manager() -> RenderManager:
     return active_render_manager
 
 

--- a/src/pyrite/core/renderer.py
+++ b/src/pyrite/core/renderer.py
@@ -28,6 +28,11 @@ def get_render_manager() -> RenderManager:
     return active_render_manager
 
 
+def set_render_manager(manager: RenderManager):
+    global active_render_manager
+    active_render_manager = manager
+
+
 class RenderManager(ABC):
     """
     An object for managing renderables. Can enable and disable them, and generates a
@@ -36,8 +41,7 @@ class RenderManager(ABC):
 
     def __new__(cls, *args, **kwds) -> Self:
         new_manager = super().__new__(cls)
-        global active_render_manager
-        active_render_manager = new_manager
+        set_render_manager(new_manager)
         return new_manager
 
     @abstractmethod

--- a/src/pyrite/core/renderer.py
+++ b/src/pyrite/core/renderer.py
@@ -116,6 +116,11 @@ class Renderer(ABC):
     Class responsible for drawing renderables to the screen.
     """
 
+    def __new__(cls) -> Self:
+        new_renderer = super().__new__(cls)
+        set_renderer(new_renderer)
+        return new_renderer
+
     @abstractmethod
     def render(
         self,

--- a/src/pyrite/core/renderer.py
+++ b/src/pyrite/core/renderer.py
@@ -49,7 +49,12 @@ _deferred_enables: set[Renderable] = set()
 
 
 def enable(renderable: Renderable):
+    """
+    Enables the renderable with the active render manager.
+    If no active render manager exists, the renderable is stored until one is created.
 
+    :param renderable: A renderable to be enabled.
+    """
     if _active_render_manager:
         _active_render_manager.enable(renderable)
         return
@@ -57,6 +62,13 @@ def enable(renderable: Renderable):
 
 
 def disable(renderable: Renderable):
+    """
+    Disables the renderable in the active render manager.
+    If not active render manager exists and the renderable is queued for enabling,
+    it is removed from the queue.
+
+    :param renderable: A renderable to be disabled.
+    """
     if _active_render_manager:
         _active_render_manager.disable(renderable)
         return

--- a/src/pyrite/core/renderer.py
+++ b/src/pyrite/core/renderer.py
@@ -48,18 +48,19 @@ def set_renderer(renderer: Renderer):
 _deferred_enables: set[Renderable] = set()
 
 
-def enable(system: Renderable):
+def enable(renderable: Renderable):
+
     if _active_render_manager:
-        _active_render_manager.enable(system)
+        _active_render_manager.enable(renderable)
         return
-    _deferred_enables.add(system)
+    _deferred_enables.add(renderable)
 
 
-def disable(system: Renderable):
+def disable(renderable: Renderable):
     if _active_render_manager:
-        _active_render_manager.disable(system)
+        _active_render_manager.disable(renderable)
         return
-    _deferred_enables.discard(system)
+    _deferred_enables.discard(renderable)
 
 
 class RenderManager(ABC):

--- a/src/pyrite/core/renderer.py
+++ b/src/pyrite/core/renderer.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 import bisect
 from collections.abc import Sequence
-from typing import Any, TYPE_CHECKING
+from typing import Any, Self, TYPE_CHECKING
 from weakref import WeakSet
 
 # from pygame.typing import Point
@@ -21,11 +21,24 @@ if TYPE_CHECKING:
 import pygame
 
 
+active_render_manager: Renderer = None
+
+
+def get_render_manager() -> Renderer:
+    return active_render_manager
+
+
 class RenderManager(ABC):
     """
     An object for managing renderables. Can enable and disable them, and generates a
     render queue for the renderer.
     """
+
+    def __new__(cls, *args, **kwds) -> Self:
+        new_manager = super().__new__(cls)
+        global active_render_manager
+        active_render_manager = new_manager
+        return new_manager
 
     @abstractmethod
     def generate_render_queue(self) -> dict[Any, Sequence[Renderable]]:

--- a/src/pyrite/core/system_manager.py
+++ b/src/pyrite/core/system_manager.py
@@ -18,7 +18,7 @@ SystemType = TypeVar("SystemType")
 _active_system_manager: SystemManager = None
 
 
-def get_system_maanger() -> SystemManager:
+def get_system_manager() -> SystemManager:
     return _active_system_manager
 
 

--- a/src/pyrite/core/system_manager.py
+++ b/src/pyrite/core/system_manager.py
@@ -15,6 +15,18 @@ if TYPE_CHECKING:
 SystemType = TypeVar("SystemType")
 
 
+_active_system_manager: SystemManager = None
+
+
+def get_system_maanger() -> SystemManager:
+    return _active_system_manager
+
+
+def set_system_manager(manager: SystemManager):
+    global _active_system_manager
+    _active_system_manager = manager
+
+
 class SystemManager(ABC):
 
     @abstractmethod

--- a/src/pyrite/core/system_manager.py
+++ b/src/pyrite/core/system_manager.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 import bisect
-from typing import TYPE_CHECKING, TypeVar
+from typing import Self, TYPE_CHECKING, TypeVar
 from weakref import WeakSet
 
 
@@ -45,6 +45,11 @@ def disable(system: System):
 
 
 class SystemManager(ABC):
+
+    def __new__(cls) -> Self:
+        new_manager = super().__new__(cls)
+        set_system_manager(new_manager)
+        return new_manager
 
     def __init__(self) -> None:
         # Subclasses must call super().__init__ at the END of initialization

--- a/src/pyrite/core/system_manager.py
+++ b/src/pyrite/core/system_manager.py
@@ -31,6 +31,12 @@ _deferred_enables: set[System] = set()
 
 
 def enable(system: System):
+    """
+    Enables a system with the active system manager.
+    If no active system manager exists, the system is stored until one is created.
+
+    :param system: A system to be enabled.
+    """
     if _active_system_manager:
         _active_system_manager.enable(system)
         return
@@ -38,6 +44,13 @@ def enable(system: System):
 
 
 def disable(system: System):
+    """
+    Disables a system in the active system maanger,
+    If no active system manager exists and the system is queued for enabling,
+    it is removed from the queue.
+
+    :param system: A system to be disabled.
+    """
     if _active_system_manager:
         _active_system_manager.disable(system)
         return

--- a/src/pyrite/game.py
+++ b/src/pyrite/game.py
@@ -63,18 +63,6 @@ def get_system_manager() -> SystemManager:
     return _retrieve_system_manager()
 
 
-def get_entity_manager() -> EntityManager:
-    """
-    Gets the EntityManager from the current game instance.
-
-    :raises RuntimeError: If no valid game is running
-    """
-    if _active_instance is None:
-        raise RuntimeError("Cannot get entity manager without a game instance running.")
-
-    return _active_instance.entity_manager
-
-
 def _retrieve_system_manager() -> SystemManager:
     return _active_instance.system_manager
 

--- a/src/pyrite/game.py
+++ b/src/pyrite/game.py
@@ -165,7 +165,7 @@ class Game:
         # global get_system_manager
         # get_system_manager = _retrieve_system_manager
         for system in self.starting_systems:
-            system(system_manager=self.system_manager)
+            system()
 
     def main(self):
         """

--- a/src/pyrite/game.py
+++ b/src/pyrite/game.py
@@ -75,31 +75,6 @@ def get_entity_manager() -> EntityManager:
     return _active_instance.entity_manager
 
 
-def get_render_manager() -> RenderManager:
-    """
-    Gets the RenderManager from the current game instance.
-
-    :raises RuntimeError: If no valid game is running
-    """
-    if _active_instance is None:
-        raise RuntimeError("Cannot get render manager without a game instance running.")
-
-    return _active_instance.render_manager
-
-
-def get_renderer() -> Renderer:
-    """
-    Gets the Renderer from the current game instance.
-
-    :raises RuntimeError: If no valid game is running
-    """
-    if _active_instance is None:
-        raise RuntimeError("Cannot get renderer without a game instance running.")
-
-    # Honestly can't see much use for this, but it won't hurt to include it.
-    return _active_instance.renderer
-
-
 def _retrieve_system_manager() -> SystemManager:
     return _active_instance.system_manager
 

--- a/src/pyrite/game.py
+++ b/src/pyrite/game.py
@@ -46,27 +46,6 @@ def set_game_instance(instance: Game):
     _active_instance = instance
 
 
-def get_system_manager() -> SystemManager:
-    """
-    Returns the current game's system manager.
-
-    Will create any starting systems the first time this is run.
-
-    :raises RuntimeError: If no valid game is running
-    """
-    if _active_instance is None:
-        raise RuntimeError("Cannot get system manager without a game instance running.")
-
-    # Ensures the starting systems have been instantiated so other objects can use them.
-    _active_instance.start_systems()
-
-    return _retrieve_system_manager()
-
-
-def _retrieve_system_manager() -> SystemManager:
-    return _active_instance.system_manager
-
-
 defaults._default_container_getter = get_game_instance
 
 
@@ -183,10 +162,10 @@ class Game:
         """
         Initializes any systems that are indicated to be required when the game starts.
         """
-        global get_system_manager
-        get_system_manager = _retrieve_system_manager
+        # global get_system_manager
+        # get_system_manager = _retrieve_system_manager
         for system in self.starting_systems:
-            system()
+            system(system_manager=self.system_manager)
 
     def main(self):
         """

--- a/src/pyrite/types/system.py
+++ b/src/pyrite/types/system.py
@@ -3,18 +3,15 @@ from abc import ABC
 
 import typing
 
-from ..core import system_manager as sm
+from ..core import system_manager
 
 if typing.TYPE_CHECKING:
-    from ..core.system_manager import SystemManager
     from pygame import Event
 
 
 class System(ABC):
 
-    def __init__(
-        self, enabled=True, order_index=0, system_manager: SystemManager = None
-    ) -> None:
+    def __init__(self, enabled=True, order_index=0) -> None:
         """
         Base class for all systems.
 
@@ -24,9 +21,6 @@ class System(ABC):
             priority going down as value increases, but negative numbers are
             approximately distance from last, defaults to 0 (Tie for first)
         """
-        if system_manager is None:
-            system_manager = sm.get_system_manager()
-        self.system_manager = system_manager
         self._enabled = None
         self.enabled = enabled
         self.order_index = order_index
@@ -39,9 +33,9 @@ class System(ABC):
     def enabled(self, value: bool):
         self._enabled = value
         if value:
-            self.system_manager.enable(self)
+            system_manager.enable(self)
         else:
-            self.system_manager.disable(self)
+            system_manager.disable(self)
 
     def pre_update(self, delta_time: float) -> None:
         """

--- a/src/pyrite/types/system.py
+++ b/src/pyrite/types/system.py
@@ -3,7 +3,7 @@ from abc import ABC
 
 import typing
 
-from .. import game
+from ..core import system_manager as sm
 
 if typing.TYPE_CHECKING:
     from ..core.system_manager import SystemManager
@@ -25,7 +25,7 @@ class System(ABC):
             approximately distance from last, defaults to 0 (Tie for first)
         """
         if system_manager is None:
-            system_manager = game.get_system_manager()
+            system_manager = sm.get_system_manager()
         self.system_manager = system_manager
         self._enabled = None
         self.enabled = enabled
@@ -38,7 +38,6 @@ class System(ABC):
     @enabled.setter
     def enabled(self, value: bool):
         self._enabled = value
-        # system_manager = game.get_system_manager()
         if value:
             self.system_manager.enable(self)
         else:

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 import pathlib
 import sys
 import unittest
-
+from weakref import WeakKeyDictionary
 
 sys.path.append(str(pathlib.Path.cwd()))
 from src.pyrite.types import Component  # noqa:E402
@@ -70,19 +70,10 @@ class TestComponent(unittest.TestCase):
         self.object8.components[2].data = "qux"
 
     def tearDown(self) -> None:
+        ComponentA.instances = WeakKeyDictionary()
+        ComponentB.instances = WeakKeyDictionary()
+        ComponentC.instances = WeakKeyDictionary()
         ComponentC.component_data = {}
-
-    def test_intersect(self):
-        shared_keys = ComponentA.intersect(ComponentB)
-        self.assertSetEqual(shared_keys, {self.object5, self.object8})
-
-        shared_keys = ComponentA.intersect(ComponentB, ComponentC)
-        self.assertSetEqual(shared_keys, {self.object8})
-
-        shared_keys = ComponentA.intersect()
-        self.assertSetEqual(
-            shared_keys, {self.object2, self.object5, self.object6, self.object8}
-        )
 
     def test_get(self):
         object2_component_a = ComponentA.get(self.object2)
@@ -92,6 +83,19 @@ class TestComponent(unittest.TestCase):
         object1_component_a = ComponentA.get(self.object1)  # No such thing
 
         self.assertIsNone(object1_component_a)
+
+    def test_intersect(self):
+        shared_keys = ComponentA.intersect(ComponentB)
+        goal_keys = {self.object5, self.object8}
+        self.assertSetEqual(shared_keys, goal_keys)
+
+        shared_keys = ComponentA.intersect(ComponentB, ComponentC)
+        goal_keys = {self.object8}
+        self.assertSetEqual(shared_keys, goal_keys)
+
+        shared_keys = ComponentA.intersect()
+        goal_keys = {self.object2, self.object5, self.object6, self.object8}
+        self.assertSetEqual(shared_keys, goal_keys)
 
     def test_remove_from(self):
         self.assertIn(self.object8, ComponentA.get_instances())


### PR DESCRIPTION
The modules for the various type managers now have module-level getters and setters for the active manager for that module, so it is no longer required to go through the game instance to access them.

Similarly, the modules also now have enable and disable functions that will either redirect to the active managers, or store the command until those managers exist. 

TODO:
- Make entities and renderable refer directly to the appropriate manager for enabling/disabling.