### PR TITLE
Component update

### DIFF
--- a/src/pyrite/types/component.py
+++ b/src/pyrite/types/component.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from abc import ABC
+from abc import ABCMeta
 from typing import TYPE_CHECKING, TypeVar
 from weakref import ref, WeakKeyDictionary
 
@@ -10,7 +10,49 @@ if TYPE_CHECKING:
 T = TypeVar("T", bound="Component")
 
 
-class Component(ABC):
+class ComponentMeta(ABCMeta):
+    """
+    Metaclass for components to allow for things like set operations on the component
+    type.
+    """
+
+    @staticmethod
+    def _validate_other(other: set | type[Component]) -> set | None:
+        if not isinstance(other, set):
+            if not isinstance(other, Component):
+                return None
+            other = set(other.instances.keys())
+        return other
+
+    def __and__(self: type[Component], other: set | type[Component]) -> set:
+        other = self._validate_other(other)
+        if other is None:
+            return NotImplemented
+        return set(self.instances.keys()) & other
+
+    def __rand__(self: type[Component], other: set | type[Component]) -> set:
+        other = self._validate_other(other)
+        if other is None:
+            return NotImplemented
+        return set(self.instances.keys()) & other
+
+    def __or__(self: type[Component], other: set | type[Component]) -> set:
+        other = self._validate_other(other)
+        if other is None:
+            return NotImplemented
+        return set(self.instances.keys()) | other
+
+    def __ror__(self: type[Component], other: set | type[Component]) -> set:
+        other = self._validate_other(other)
+        if other is None:
+            return NotImplemented
+        return set(self.instances.keys()) | other
+
+    def __contains__(self: type[Component], value: Any) -> bool:
+        return value in self.instances.keys()
+
+
+class Component(metaclass=ComponentMeta):
     """
     Components are objects that mark other object with attributes. Components can be
     intersected with other components to get a set of shared key objects.

--- a/src/pyrite/types/component.py
+++ b/src/pyrite/types/component.py
@@ -19,7 +19,7 @@ class ComponentMeta(ABCMeta):
     @staticmethod
     def _validate_other(other: set | type[Component]) -> set | None:
         if not isinstance(other, set):
-            if not isinstance(other, Component):
+            if not isinstance(other, ComponentMeta):
                 return None
             other = set(other.instances.keys())
         return other

--- a/src/pyrite/types/component.py
+++ b/src/pyrite/types/component.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, TypeVar
 from weakref import ref, WeakKeyDictionary
 
 if TYPE_CHECKING:
-    from typing import Any, Self
+    from typing import Any
 
 T = TypeVar("T", bound="Component")
 
@@ -21,7 +21,7 @@ class Component(ABC):
     def __init_subclass__(cls: type[T]) -> None:
         cls.instances: WeakKeyDictionary[Any, T] = WeakKeyDictionary()
 
-    def __new__(cls: type[T], owner: Any, *args, **kwds) -> Self:
+    def __new__(cls: type[T], owner: Any, *args, **kwds) -> T:
         new_component = super().__new__(cls)
         cls.instances.update({owner: new_component})
         return new_component

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -106,6 +106,30 @@ class TestComponent(unittest.TestCase):
         goal_keys = {self.object8}
         self.assertSetEqual(shared_keys, goal_keys)
 
+    def test_or(self):
+        either_keys = ComponentA | ComponentB
+        goal_keys = {
+            self.object2,
+            self.object3,
+            self.object5,
+            self.object6,
+            self.object7,
+            self.object8,
+        }
+        self.assertSetEqual(either_keys, goal_keys)
+
+        either_keys = ComponentA | ComponentB | ComponentC
+        goal_keys = {
+            self.object2,
+            self.object3,
+            self.object4,
+            self.object5,
+            self.object6,
+            self.object7,
+            self.object8,
+        }
+        self.assertSetEqual(either_keys, goal_keys)
+
     def test_remove_from(self):
         self.assertIn(self.object8, ComponentA.get_instances())
 

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -130,6 +130,14 @@ class TestComponent(unittest.TestCase):
         }
         self.assertSetEqual(either_keys, goal_keys)
 
+    def test_contains(self):
+
+        self.assertTrue(self.object2 in ComponentA)
+
+        self.assertFalse(self.object3 in ComponentA)
+
+        self.assertTrue(self.object3 not in ComponentA)
+
     def test_remove_from(self):
         self.assertIn(self.object8, ComponentA.get_instances())
 

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -97,6 +97,15 @@ class TestComponent(unittest.TestCase):
         goal_keys = {self.object2, self.object5, self.object6, self.object8}
         self.assertSetEqual(shared_keys, goal_keys)
 
+    def test_and(self):
+        shared_keys = ComponentA & ComponentB
+        goal_keys = {self.object5, self.object8}
+        self.assertSetEqual(shared_keys, goal_keys)
+
+        shared_keys = ComponentA & ComponentB & ComponentC
+        goal_keys = {self.object8}
+        self.assertSetEqual(shared_keys, goal_keys)
+
     def test_remove_from(self):
         self.assertIn(self.object8, ComponentA.get_instances())
 


### PR DESCRIPTION
Updates the Component base class.

## Adds
- Give component subclasses set operations for getting keys. For example, `ComponentA & ComponentB` would return the keys shared by both components. These can be chained together to create complex key generation for use by systems.

## Fixes
- A bug where creating a new component from a subclass would have its static type rendered as the parent Component class.