### PR TITLE
Extract concrete from types

### DIFF
--- a/src/pyrite/__init__.py
+++ b/src/pyrite/__init__.py
@@ -8,6 +8,7 @@ from .game import (  # noqa: F401
 )
 
 from .camera import Camera, ChaseCamera  # noqa: F401
+from .entity import Entity  # noqa:F401
 from .enum import RenderLayers, AnchorPoint  # noqa: F401
 from .physics import (  # noqa: F401
     ColliderComponent,
@@ -19,4 +20,3 @@ from .sprite.sprite import Sprite  # noqa: F401
 from .sprite.spritesheet import SpriteSheet, SpriteMap  # noqa: F401
 from .systems import System  # noqa: F401
 from .transform import Transform, TransformComponent  # noqa: F401
-from .types.entity import Entity  # noqa:F401

--- a/src/pyrite/camera/chase_camera.py
+++ b/src/pyrite/camera/chase_camera.py
@@ -4,7 +4,7 @@ from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 from .camera import Camera
-from ..types.entity import Entity
+from ..entity import Entity
 
 from pygame import Vector2
 

--- a/src/pyrite/component/__init__.py
+++ b/src/pyrite/component/__init__.py
@@ -1,0 +1,1 @@
+from .component import BaseComponent as Component  # noqa: F401

--- a/src/pyrite/entity/__init__.py
+++ b/src/pyrite/entity/__init__.py
@@ -1,0 +1,1 @@
+from .entity import BaseEntity as Entity  # noqa: F401

--- a/src/pyrite/entity/entity.py
+++ b/src/pyrite/entity/entity.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ..core import entity_manager
+from ..types import Entity
+
+if TYPE_CHECKING:
+    from pygame import Event
+
+
+class BaseEntity(Entity):
+    """
+    Base class for any class that exhibits behaviour during any of the update phases.
+    """
+
+    def __init__(self, enabled=True) -> None:
+        self.enabled = enabled
+
+    @property
+    def enabled(self) -> bool:
+        return entity_manager.is_enabled(self)
+
+    @enabled.setter
+    def enabled(self, value: bool) -> None:
+        self._enabled = value
+        if value:
+            self.on_preenable()
+            if entity_manager.enable(self):
+                self.on_enable()
+        else:
+            self.on_predisable()
+            if entity_manager.disable(self):
+                self.on_disable()
+
+    def on_preenable(self):
+        pass
+
+    def on_enable(self):
+        pass
+
+    def on_predisable(self):
+        pass
+
+    def on_disable(self):
+        pass
+
+    def pre_update(self, delta_time: float) -> None:
+        pass
+
+    def update(self, delta_time: float) -> None:
+        pass
+
+    def post_update(self, delta_time: float) -> None:
+        pass
+
+    def const_update(self, timestep: float) -> None:
+        pass
+
+    def on_event(self, event: Event):
+        pass

--- a/src/pyrite/events/__init__.py
+++ b/src/pyrite/events/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from typing import TYPE_CHECKING
-from ..types.instance_event import InstanceEvent  # noqa:F401
+
+from .instance_event import BaseInstanceEvent as InstanceEvent
 
 if TYPE_CHECKING:
     from ..physics.collider_component import ColliderComponent

--- a/src/pyrite/events/instance_event.py
+++ b/src/pyrite/events/instance_event.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from abc import abstractmethod
+from collections.abc import Callable
+from functools import singledispatchmethod
+from typing import Any, Generic, TypeVar, TYPE_CHECKING
+from weakref import ref, WeakKeyDictionary
+
+from ..types.instance_event import InstanceEvent
+
+# This is NOT the standard library threading module.
+from ..utils import threading
+
+if TYPE_CHECKING:
+    pass
+
+T = TypeVar("T")
+
+
+class _Sentinel:
+
+    pass
+
+
+SENTINEL = _Sentinel()
+
+
+class BaseInstanceEvent(InstanceEvent, Generic[T]):
+    """
+    Events that are bound to an instance of an object. They accumulate listeners, which
+    respond when the event fires.
+
+    The __call__ method defines the event's parameters, which will be passed on to the
+    listener. The listener must be able to receive these parameters, or else will error.
+    For implementation of __call__, either forward the event parameters to
+    super().__call__() [The default], or forward them into _notify().
+
+    For user-created events, they are fired by calling the event, passing along its
+    parameters.
+
+    ------------------Naming Conventions-----------------
+
+    Objects with instance events should have those events as attributes. Pyrite uses
+    PascalCase/UpperCamelCase for event attribute names, like used with class names, to
+    help to convey that they are a distinct type of attribute.
+
+    The attributes should have docstrings containing the event signature of the event
+    they relate to.
+
+    Instance event classes should start with "On" to convey that they are events.
+    """
+
+    def __init__(self, instance: T) -> None:
+        """
+        Creates a new instance of the Instance Event.
+
+        :param instance: The object the instance event is tied to. This allows access
+        to the owning instance if needed.
+        """
+        self._instance = ref(instance)
+        self.listeners: WeakKeyDictionary[Any, list[Callable]] = WeakKeyDictionary()
+        """
+        A set containing all listeners for this event instance.
+
+        TODO: Consider who should be responsible for tracking listeners.
+        Currently, the object creating the listener is responsible, with this set only
+        being for calling them.
+        """
+
+    @property
+    def instance(self) -> T | None:
+        # Provides dereferenced access to the owning instance
+        return self._instance()
+
+    @abstractmethod
+    def __call__(self, *args: Any, **kwds: Any) -> None:
+        self._notify(*args, **kwds)
+
+    @singledispatchmethod
+    def add_listener(self, arg) -> Callable:
+        raise NotImplementedError("Argument type not supported")
+
+    @add_listener.register(Callable)  # type: ignore
+    def _(self, listener: Callable) -> Callable:
+        self._register(SENTINEL, listener)
+        return listener
+
+    @add_listener.register(object)
+    def _(self, caller: object) -> Callable:
+
+        def inner(listener: Callable):
+            self._register(caller, listener)
+            return listener
+
+        return inner
+
+    def _register(self, caller, listener: Callable):
+        listeners = self.listeners.setdefault(caller, [])
+        # TODO Test if method, keep methods and function in two different sets?
+        listeners.append(listener)
+
+    def _deregister(self, listener: Callable):
+        for caller, listeners in self.listeners.items():
+            if listener in listeners:
+                listeners.remove(listener)
+                # Note: if a listener managed to get in there multiple times,
+                # this will only remove one occurence.
+                # If that happens, though, something went horribly wrong.
+                # See you in 2 years!
+                break
+
+    def _notify(self, *args, **kwds):
+        """
+        Calls all registered listeners, passing along the args and kwds.
+        This is never called directly, the instance event subclass will have its own
+        defined call method that defines its parameters, which are passed on to the
+        listeners.
+        """
+
+        # Decision was made for all instance event listeners to be async.
+        # The risk of race conditions is inevitable, and while synchronous calls can't
+        # technically form race conditions, the fact that they can be called at any
+        # time means it's always possible to have even a sync event make a change at an
+        # unexpected time, mirorring a race condition.
+
+        # Threads also adds the benefit of an exception not necessarily crashing the
+        # entire game, just the thread.
+
+        # TODO If there is demand for sync listeners, make them the exception, not the
+        # rule. Add a separate list and registration method for those.
+        for caller, listeners in self.listeners.items():
+            # The pyrite threading module can be set to run regular threads or asyncio
+            # threads.
+            if caller is not SENTINEL:
+                for listener in listeners:
+                    threading.start_thread(listener, *(caller, *args))
+                continue
+            for listener in listeners:
+                threading.start_thread(listener, *args)

--- a/src/pyrite/physics/collider_component.py
+++ b/src/pyrite/physics/collider_component.py
@@ -10,7 +10,7 @@ from ..constants import COMPONENT_TYPE
 from ..events import OnSeparate, OnTouch, WhileTouching
 from .rigidbody_component import RigidbodyComponent
 from ..services import PhysicsService
-from ..types import Component
+from ..component import Component
 
 if TYPE_CHECKING:
     from pymunk import Shape

--- a/src/pyrite/physics/kinematic_component.py
+++ b/src/pyrite/physics/kinematic_component.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any
 
 from pygame import Vector2
 
-from ..types import Component
+from ..component import Component
 from .rigidbody_component import RigidbodyComponent
 
 if TYPE_CHECKING:

--- a/src/pyrite/physics/rigidbody_component.py
+++ b/src/pyrite/physics/rigidbody_component.py
@@ -6,7 +6,7 @@ from weakref import ref
 from pymunk import Body
 
 from ..transform import TransformComponent
-from ..types import Component
+from ..component import Component
 from ..services import PhysicsService
 
 if TYPE_CHECKING:

--- a/src/pyrite/rendering/render_texture.py
+++ b/src/pyrite/rendering/render_texture.py
@@ -4,7 +4,8 @@ from typing import cast, TYPE_CHECKING
 
 from pygame import Rect, Surface
 
-from ..types import Component, HasTexture
+from ..component import Component
+from ..types import HasTexture
 
 if TYPE_CHECKING:
     from pygame.typing import Point

--- a/src/pyrite/transform/transform_component.py
+++ b/src/pyrite/transform/transform_component.py
@@ -4,9 +4,10 @@ from typing import Any, TYPE_CHECKING
 
 from pygame import Vector2
 
+from ..component import Component
 from .transform import Transform
 from ..services import TransformService
-from ..types import Component, TransformLike
+from ..types import TransformLike
 
 
 if TYPE_CHECKING:

--- a/src/pyrite/types/entity.py
+++ b/src/pyrite/types/entity.py
@@ -1,39 +1,26 @@
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
-from ..core import entity_manager
-
 if TYPE_CHECKING:
-    pass
-
-import pygame
+    from pygame import Event
 
 
-class Entity:
+class Entity(ABC):
     """
     Base class for any class that exhibits behaviour during any of the update phases.
     """
 
-    def __init__(self, enabled=True) -> None:
-        self.enabled = enabled
-
     @property
-    def enabled(self) -> bool:
-        return entity_manager.is_enabled(self)
+    @abstractmethod
+    def enabled(self) -> bool: ...
 
     @enabled.setter
-    def enabled(self, value: bool) -> None:
-        self._enabled = value
-        if value:
-            self.on_preenable()
-            if entity_manager.enable(self):
-                self.on_enable()
-        else:
-            self.on_predisable()
-            if entity_manager.disable(self):
-                self.on_disable()
+    @abstractmethod
+    def enabled(self, value: bool) -> None: ...
 
+    @abstractmethod
     def on_preenable(self):
         """
         Event called just before the object is enabled.
@@ -42,7 +29,9 @@ class Entity:
         Does NOT guarantee the object is not already enabled.
 
         """
+        ...
 
+    @abstractmethod
     def on_enable(self):
         """
         Event called just after the object has been enabled.
@@ -51,7 +40,9 @@ class Entity:
         Guarantees the object is now enabled, and only runs when the object was
         previously disabled.
         """
+        ...
 
+    @abstractmethod
     def on_predisable(self):
         """
         Event called just before the object is disabled.
@@ -59,7 +50,9 @@ class Entity:
         disabling.
         Does NOT guarantee the object has not already been disabled.
         """
+        ...
 
+    @abstractmethod
     def on_disable(self):
         """
         Event called just after the object has been disabled.
@@ -68,7 +61,9 @@ class Entity:
         Guarantees the object is now disabled, and that the object was previously
         disabled.
         """
+        ...
 
+    @abstractmethod
     def pre_update(self, delta_time: float) -> None:
         """
         A method that is called during the pre_update phase.
@@ -76,8 +71,9 @@ class Entity:
 
         :param delta_time: Time passed since last frame.
         """
-        pass
+        ...
 
+    @abstractmethod
     def update(self, delta_time: float) -> None:
         """
         A method that is called during the main update phase.
@@ -85,8 +81,9 @@ class Entity:
 
         :param delta_time: Time passed since last frame.
         """
-        pass
+        ...
 
+    @abstractmethod
     def post_update(self, delta_time: float) -> None:
         """
         A method that is called during the post_update phase.
@@ -94,8 +91,9 @@ class Entity:
 
         :param delta_time: Time passed since last frame.
         """
-        pass
+        ...
 
+    @abstractmethod
     def const_update(self, timestep: float) -> None:
         """
         A method that is called during the const_update phase.
@@ -109,13 +107,14 @@ class Entity:
 
         :param timestep: Length of the timestep being simulated.
         """
-        pass
+        ...
 
-    def on_event(self, event: pygame.Event):
+    @abstractmethod
+    def on_event(self, event: Event):
         """
         An event hook. Events will be passed to the entity when it's enabled, and can
         be handled here.
 
         :param event: A pygame event.
         """
-        pass
+        ...

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -5,7 +5,7 @@ import unittest
 from weakref import WeakKeyDictionary
 
 sys.path.append(str(pathlib.Path.cwd()))
-from src.pyrite.types import Component  # noqa:E402
+from src.pyrite.component import Component  # noqa:E402
 
 
 class ComponentA(Component):

--- a/tests/test_entity_manager.py
+++ b/tests/test_entity_manager.py
@@ -2,6 +2,7 @@
 from contextlib import contextmanager
 import pathlib
 import sys
+from typing import cast
 from weakref import WeakSet
 
 # from typing import Any
@@ -11,10 +12,13 @@ import unittest
 sys.path.append(str(pathlib.Path.cwd()))
 
 from src.pyrite.core.entity_manager import DefaultEntityManager  # noqa:E402
-from src.pyrite.types.entity import Entity  # noqa:E402
+from src.pyrite.entity import Entity  # noqa:E402
 
 
 class MockEntity(Entity):
+
+    def __new__(cls, *args, **kwds) -> Entity:
+        return cast(Entity, super().__new__(cls))
 
     def __init__(self, game_instance=None, enabled=True) -> None:
         pass

--- a/tests/test_instance_event.py
+++ b/tests/test_instance_event.py
@@ -5,7 +5,8 @@ from weakref import WeakKeyDictionary
 
 
 sys.path.append(str(pathlib.Path.cwd()))
-from src.pyrite.types.instance_event import InstanceEvent, SENTINEL  # noqa:E402
+from src.pyrite.events import InstanceEvent  # noqa:E402
+from src.pyrite.events.instance_event import SENTINEL  # noqa:E402
 from src.pyrite.utils import threading  # noqa:E402
 
 


### PR DESCRIPTION
This PR ensures that there is no longer any concrete implementation inside the types folder, so there are only ever protocols and ABCs inside. This should help prevent import loops in future code, if we can stick to this standard.