### PR TITLE
Parameterize unit tests

### DIFF
--- a/tests/test_anchor.py
+++ b/tests/test_anchor.py
@@ -19,31 +19,23 @@ rect_size: RectLike = (0, 0, 8, 4)
 
 class TestAnchor(unittest.TestCase):
 
-    def get_center_offset(
-        self, anchor_point: Point, rect_size: RectLike, expected: Point
-    ):
-        anchor = Anchor(anchor_point)
-        rect = Rect(rect_size)
-        pivot = anchor.get_center_offset(rect)
-
-        expected_vector = Vector2(expected)
-
-        self.assertEqual(pivot, expected_vector)
-
     def test_get_center_offset(self):
-        test_params: list[tuple[Point, RectLike, Point]] = [
-            # Center Anchor
-            (anchor_center, rect_size, (0, 0)),
-            # Center X, 3/4 Y
-            ((0.5, 0.75), rect_size, (0, 1)),
-            # 3/4 X, Center Y
-            ((0.75, 0.5), rect_size, (2, 0)),
-            # 1/4 X, 1/4 Y
-            ((0.25, 0.25), rect_size, (-2, -1)),
-        ]
+        test_params: dict[str, tuple[Point, RectLike, Point]] = {
+            "Center Anchor": (anchor_center, rect_size, (0, 0)),
+            "Center X, 3/4 Y": ((0.5, 0.75), rect_size, (0, 1)),
+            "3/4 X, Center Y": ((0.75, 0.5), rect_size, (2, 0)),
+            "1/4 X, 1/4 Y": ((0.25, 0.25), rect_size, (-2, -1)),
+        }
 
-        for params in test_params:
-            self.get_center_offset(*params)
+        for index, (case, params) in enumerate(test_params.items()):
+            with self.subTest(case, i=index):
+                anchor = Anchor(params[0])
+                rect = Rect(params[1])
+                expected = Vector2(params[2])
+
+                pivot = anchor.get_center_offset(rect)
+
+                self.assertEqual(pivot, expected)
 
     def test_get_rect_center(self):
         # Case: (Center X, Center Y), 0 C

--- a/tests/test_anchor.py
+++ b/tests/test_anchor.py
@@ -14,7 +14,13 @@ sys.path.append(str(pathlib.Path.cwd()))
 from src.pyrite.enum import Anchor  # noqa:E402
 
 anchor_center: Point = (0.5, 0.5)
+anchor_75x_5y: Point = (0.75, 0.5)
+anchor_5x_75y: Point = (0.5, 0.75)
+anchor_quarter: Point = (0.25, 0.25)
+
 rect_size: RectLike = (0, 0, 8, 4)
+
+default_scale: Point = (1, 1)
 
 
 class TestAnchor(unittest.TestCase):
@@ -22,9 +28,9 @@ class TestAnchor(unittest.TestCase):
     def test_get_center_offset(self):
         test_params: dict[str, tuple[Point, RectLike, Point]] = {
             "Center Anchor": (anchor_center, rect_size, (0, 0)),
-            "Center X, 3/4 Y": ((0.5, 0.75), rect_size, (0, 1)),
-            "3/4 X, Center Y": ((0.75, 0.5), rect_size, (2, 0)),
-            "1/4 X, 1/4 Y": ((0.25, 0.25), rect_size, (-2, -1)),
+            "Center X, 3/4 Y": (anchor_5x_75y, rect_size, (0, 1)),
+            "3/4 X, Center Y": (anchor_75x_5y, rect_size, (2, 0)),
+            "1/4 X, 1/4 Y": (anchor_quarter, rect_size, (-2, -1)),
         }
 
         for index, (case, params) in enumerate(test_params.items()):
@@ -38,63 +44,56 @@ class TestAnchor(unittest.TestCase):
                 self.assertEqual(pivot, expected)
 
     def test_get_rect_center(self):
-        # Case: (Center X, Center Y), 0 C
-        rect = Rect(0, 0, 8, 4)
-        anchor = Anchor((0.5, 0.5))
-        angle = 0
+        test_params: dict[str, tuple[Point, float, Point, Point]] = {
+            "Case: (Center X, Center Y), 0 C": (
+                anchor_center,
+                0,
+                default_scale,
+                (6, -2),
+            ),
+            "Case: (3/4 X, Center Y), 0 C": (
+                anchor_75x_5y,
+                0,
+                default_scale,
+                (4, -2),
+            ),
+            "Case: (3/4 X, Center Y), 90 C": (
+                anchor_75x_5y,
+                90,
+                default_scale,
+                (6, -4),
+            ),
+            "Case: (3/4 X, Center Y), -90 C": (
+                anchor_75x_5y,
+                -90,
+                default_scale,
+                (6, 0),
+            ),
+            "Case: (3/4 X, Center Y), 180 C": (
+                anchor_75x_5y,
+                180,
+                default_scale,
+                (8, -2),
+            ),
+            "Case: (3/4 X, Center Y), 0 C, (2,2) scale": (
+                anchor_75x_5y,
+                0,
+                (2, 2),
+                (2, -2),
+            ),
+        }
 
-        new_center = anchor.get_rect_center(rect, (6, -2), angle)
+        for index, (case, params) in enumerate(test_params.items()):
+            with self.subTest(case, i=index):
+                rect = Rect(rect_size)
+                anchor = Anchor(params[0])
+                angle = params[1]
+                scale = params[2]
+                expected = Vector2(params[3])
 
-        expected = Vector2(6, -2)
+                new_center = anchor.get_rect_center(rect, (6, -2), angle, scale)
 
-        self.assertEqual(new_center, expected)
-
-        # Case: (3/4 X, Center Y), 0 C
-        anchor = Anchor((0.75, 0.5))
-        angle = 0
-
-        new_center = anchor.get_rect_center(rect, (6, -2), angle)
-
-        expected = Vector2(4, -2)
-
-        self.assertEqual(new_center, expected)
-
-        # Case: (3/4 X, Center Y), 90 C
-        angle = 90
-
-        new_center = anchor.get_rect_center(rect, (6, -2), angle)
-
-        expected = Vector2(6, -4)
-
-        self.assertEqual(new_center, expected)
-
-        # Case: (3/4 X, Center Y), -90 C
-        angle = -90
-
-        new_center = anchor.get_rect_center(rect, (6, -2), angle)
-
-        expected = Vector2(6, 0)
-
-        self.assertEqual(new_center, expected)
-
-        # Case: (3/4 X, Center Y), 180 C
-        angle = 180
-
-        new_center = anchor.get_rect_center(rect, (6, -2), angle)
-
-        expected = Vector2(8, -2)
-
-        self.assertEqual(new_center, expected)
-
-        # Case: (3/4 X, Center Y), 0 C, (2,2) scale
-        angle = 0
-        scale = (2, 2)
-
-        new_center = anchor.get_rect_center(rect, (6, -2), angle, scale)
-
-        expected = Vector2(2, -2)
-
-        self.assertEqual(new_center, expected)
+                self.assertEqual(new_center, expected)
 
 
 if __name__ == "__main__":

--- a/tests/test_anchor.py
+++ b/tests/test_anchor.py
@@ -1,53 +1,49 @@
 from __future__ import annotations
 import pathlib
 import sys
+from typing import TYPE_CHECKING
 import unittest
 
 from pygame import Rect, Vector2
+
+if TYPE_CHECKING:
+    from pygame.typing import Point, RectLike
 
 
 sys.path.append(str(pathlib.Path.cwd()))
 from src.pyrite.enum import Anchor  # noqa:E402
 
+anchor_center: Point = (0.5, 0.5)
+rect_size: RectLike = (0, 0, 8, 4)
+
 
 class TestAnchor(unittest.TestCase):
 
+    def get_center_offset(
+        self, anchor_point: Point, rect_size: RectLike, expected: Point
+    ):
+        anchor = Anchor(anchor_point)
+        rect = Rect(rect_size)
+        pivot = anchor.get_center_offset(rect)
+
+        expected_vector = Vector2(expected)
+
+        self.assertEqual(pivot, expected_vector)
+
     def test_get_center_offset(self):
-        # Center anchor
-        anchor = Anchor((0.5, 0.5))
-        rect = Rect(0, 0, 8, 4)
+        test_params: list[tuple[Point, RectLike, Point]] = [
+            # Center Anchor
+            (anchor_center, rect_size, (0, 0)),
+            # Center X, 3/4 Y
+            ((0.5, 0.75), rect_size, (0, 1)),
+            # 3/4 X, Center Y
+            ((0.75, 0.5), rect_size, (2, 0)),
+            # 1/4 X, 1/4 Y
+            ((0.25, 0.25), rect_size, (-2, -1)),
+        ]
 
-        pivot = anchor.get_center_offset(rect)
-
-        self.assertEqual(pivot.x, 0)
-        self.assertEqual(pivot.y, 0)
-
-        # Center X, 3/4 Y
-
-        anchor = Anchor((0.5, 0.75))
-
-        pivot = anchor.get_center_offset(rect)
-
-        self.assertEqual(pivot.x, 0)
-        self.assertEqual(pivot.y, 1)
-
-        # 3/4 X, Center Y
-
-        anchor = Anchor((0.75, 0.5))
-
-        pivot = anchor.get_center_offset(rect)
-
-        self.assertEqual(pivot.x, 2)
-        self.assertEqual(pivot.y, 0)
-
-        # 1/4 X, 1/4 Y
-
-        anchor = Anchor((0.25, 0.25))
-
-        pivot = anchor.get_center_offset(rect)
-
-        self.assertEqual(pivot.x, -2)
-        self.assertEqual(pivot.y, -1)
+        for params in test_params:
+            self.get_center_offset(*params)
 
     def test_get_rect_center(self):
         # Case: (Center X, Center Y), 0 C

--- a/tests/test_camera_service.py
+++ b/tests/test_camera_service.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
 centered_projection = OrthoProjection(Rect(-400, -300, 800, 600))
 three_quart_projection = OrthoProjection(Rect(-200, -150, 800, 600))
 zero_vector = Vector3(0, 0, 0)
-zero_transform = Transform((0, 0), 0, (1, 1))
+zero_transform = Transform()
 
 
 class MockCamera:
@@ -160,8 +160,8 @@ class TestCameraService(unittest.TestCase):
                 self.assertEqual(local_position, expected)
 
     def test_to_local(self):
-        shifted_pos_transform = Transform((10, 0), 0, (1, 1))
-        shifted_post_rot_transform = Transform((10, 0), 90, (1, 1))
+        shifted_pos_transform = Transform((10, 0))
+        shifted_post_rot_transform = Transform((10, 0), 90)
 
         test_params: dict[
             str, tuple[WorldTransform, WorldTransform, LocalTransform]
@@ -180,7 +180,7 @@ class TestCameraService(unittest.TestCase):
             "Shifted camera, Default test position": (
                 shifted_pos_transform,
                 zero_transform,
-                Transform((-10, 0), 0, (1, 1)),
+                Transform((-10, 0)),
             ),
         }
 
@@ -205,12 +205,12 @@ class TestCameraService(unittest.TestCase):
             "3/4 projection, local 0 coords": (
                 three_quart_projection,
                 zero_transform,
-                Transform((200, 150), 0, (1, 1)),
+                Transform((200, 150)),
                 1,
             ),
             "3/4 projection, counter local coords": (
                 three_quart_projection,
-                Transform((-200, -150), 0, (1, 1)),
+                Transform((-200, -150)),
                 zero_transform,
                 1,
             ),

--- a/tests/test_camera_service.py
+++ b/tests/test_camera_service.py
@@ -197,45 +197,41 @@ class TestCameraService(unittest.TestCase):
 
                 self.assertEqual(local_transform, expected)
 
-    def to_eye(
-        self,
-        projection: Projection,
-        local_transform: LocalTransform,
-        expected: EyeTransform,
-        zoom_level: ZoomLevel = 1,
-    ):
-        test_cam = MockCamera(projection)
-        test_cam.zoom_level = zoom_level
-
-        eye_transform = CameraService.to_eye(test_cam, local_transform)
-
-        self.assertEqual(eye_transform, expected)
-
     def test_to_eye(self):
 
-        test_params: list[
-            tuple[Projection, LocalTransform, EyeTransform, ZoomLevel]
-        ] = [
-            # 3/4 projection, local 0 coords
-            (
+        test_params: dict[
+            str, tuple[Projection, LocalTransform, EyeTransform, ZoomLevel]
+        ] = {
+            "3/4 projection, local 0 coords": (
                 three_quart_projection,
                 zero_transform,
                 Transform((200, 150), 0, (1, 1)),
                 1,
             ),
-            # 3/4 projection, counter local coords
-            (
+            "3/4 projection, counter local coords": (
                 three_quart_projection,
                 Transform((-200, -150), 0, (1, 1)),
                 zero_transform,
                 1,
             ),
-            # Centered projection, off center camera, origin test transform
-            (centered_projection, zero_transform, zero_transform, 1),
-        ]
+            "Centered projection, off center camera, origin test transform": (
+                centered_projection,
+                zero_transform,
+                zero_transform,
+                1,
+            ),
+        }
 
-        for params in test_params:
-            self.to_eye(*params)
+        for index, (case, params) in enumerate(test_params.items()):
+            with self.subTest(case, i=index):
+                projection, local_transform, expected, zoom_level = params
+
+                test_cam = MockCamera(projection)
+                test_cam.zoom_level = zoom_level
+
+                eye_transform = CameraService.to_eye(test_cam, local_transform)
+
+                self.assertEqual(eye_transform, expected)
 
     def test_to_world(self):
         # Centered projection, both default transform

--- a/tests/test_camera_service.py
+++ b/tests/test_camera_service.py
@@ -103,38 +103,61 @@ class TestCameraService(unittest.TestCase):
                 ndc_coords = CameraService.local_to_ndc(test_cam, local_position)
                 self.assertEqual(ndc_coords, expected)
 
-    def ndc_to_local(
-        self,
-        projection: OrthoProjection,
-        ndc_coords: NDCCoords,
-        expected: LocalCoords,
-        zoom_level: ZoomLevel = 1,
-    ):
-        test_cam = MockCamera(projection)
-        test_cam.zoom_level = zoom_level
-        local_position = CameraService.ndc_to_local(test_cam, ndc_coords)
-        self.assertEqual(local_position, expected)
-
     def test_ndc_to_local(self):
-        test_params: list[tuple[OrthoProjection, NDCCoords, LocalCoords, ZoomLevel]] = [
-            # Centered projection, center coords
-            (centered_projection, zero_vector, zero_vector, 1),
-            # Centered projection, corner coords
-            (centered_projection, Vector3(-1, -1, 1), Vector3(-400, -300, 1), 1),
-            # 3/4 projection, local 0 coords
-            (three_quart_projection, Vector3(-0.5, -0.5, 0), zero_vector, 1),
-            # 3/4 projection, center coords
-            (three_quart_projection, zero_vector, Vector3(200, 150, 0), 1),
-            # 3/4 projection, corner coords
-            (three_quart_projection, Vector3(-1, -1, 0), Vector3(-200, -150, 0), 1),
-            # Centered projection, center coords, zoom level 2
-            (centered_projection, zero_vector, zero_vector, 2),
-            # Centered projection, corner coords, zoom level 2
-            (centered_projection, Vector3(-1, -1, 1), Vector3(-200, -150, 1), 2),
-        ]
+        test_params: dict[
+            str, tuple[OrthoProjection, NDCCoords, LocalCoords, ZoomLevel]
+        ] = {
+            "Centered projection, center coords": (
+                centered_projection,
+                zero_vector,
+                zero_vector,
+                1,
+            ),
+            "Centered projection, corner coords": (
+                centered_projection,
+                Vector3(-1, -1, 1),
+                Vector3(-400, -300, 1),
+                1,
+            ),
+            "3/4 projection, local 0 coords": (
+                three_quart_projection,
+                Vector3(-0.5, -0.5, 0),
+                zero_vector,
+                1,
+            ),
+            "3/4 projection, center coords": (
+                three_quart_projection,
+                zero_vector,
+                Vector3(200, 150, 0),
+                1,
+            ),
+            "3/4 projection, corner coords": (
+                three_quart_projection,
+                Vector3(-1, -1, 0),
+                Vector3(-200, -150, 0),
+                1,
+            ),
+            "Centered projection, center coords, zoom level 2": (
+                centered_projection,
+                zero_vector,
+                zero_vector,
+                2,
+            ),
+            "Centered projection, corner coords, zoom level 2": (
+                centered_projection,
+                Vector3(-1, -1, 1),
+                Vector3(-200, -150, 1),
+                2,
+            ),
+        }
 
-        for params in test_params:
-            self.ndc_to_local(*params)
+        for index, (case, params) in enumerate(test_params.items()):
+            with self.subTest(case, i=index):
+                projection, ndc_coords, expected, zoom_level = params
+                test_cam = MockCamera(projection)
+                test_cam.zoom_level = zoom_level
+                local_position = CameraService.ndc_to_local(test_cam, ndc_coords)
+                self.assertEqual(local_position, expected)
 
     def to_local(
         self,

--- a/tests/test_camera_service.py
+++ b/tests/test_camera_service.py
@@ -159,42 +159,43 @@ class TestCameraService(unittest.TestCase):
                 local_position = CameraService.ndc_to_local(test_cam, ndc_coords)
                 self.assertEqual(local_position, expected)
 
-    def to_local(
-        self,
-        camera_transform: WorldTransform,
-        world_transform: WorldTransform,
-        expected: LocalTransform,
-    ):
-        test_cam = MockCamera(centered_projection)
-        test_cam.transform.world_position = camera_transform.position
-        test_cam.transform.world_rotation = camera_transform.rotation
-        test_cam.transform.world_scale = camera_transform.scale
-
-        local_transform = CameraService.to_local(test_cam, world_transform)
-
-        self.assertEqual(local_transform, expected)
-
     def test_to_local(self):
         shifted_pos_transform = Transform((10, 0), 0, (1, 1))
         shifted_post_rot_transform = Transform((10, 0), 90, (1, 1))
 
-        test_params: list[tuple[WorldTransform, WorldTransform, LocalTransform]] = [
-            # Both default transform
-            (zero_transform, zero_transform, zero_transform),
-            # Default camera, Different test position,
-            (
+        test_params: dict[
+            str, tuple[WorldTransform, WorldTransform, LocalTransform]
+        ] = {
+            "Both default transform": (zero_transform, zero_transform, zero_transform),
+            "Default camera, Different test position": (
                 zero_transform,
                 shifted_pos_transform,
                 shifted_pos_transform,
             ),
-            # Default camera, Different test position, rotation,
-            (zero_transform, shifted_post_rot_transform, shifted_post_rot_transform),
-            # Shifted camera, Default test position
-            (shifted_pos_transform, zero_transform, Transform((-10, 0), 0, (1, 1))),
-        ]
+            "Default camera, Different test position, rotation": (
+                zero_transform,
+                shifted_post_rot_transform,
+                shifted_post_rot_transform,
+            ),
+            "Shifted camera, Default test position": (
+                shifted_pos_transform,
+                zero_transform,
+                Transform((-10, 0), 0, (1, 1)),
+            ),
+        }
 
-        for params in test_params:
-            self.to_local(*params)
+        for index, (case, params) in enumerate(test_params.items()):
+            with self.subTest(case, i=index):
+                camera_transform, world_transform, expected = params
+
+                test_cam = MockCamera(centered_projection)
+                test_cam.transform.world_position = camera_transform.position
+                test_cam.transform.world_rotation = camera_transform.rotation
+                test_cam.transform.world_scale = camera_transform.scale
+
+                local_transform = CameraService.to_local(test_cam, world_transform)
+
+                self.assertEqual(local_transform, expected)
 
     def to_eye(
         self,

--- a/tests/test_camera_service.py
+++ b/tests/test_camera_service.py
@@ -47,38 +47,61 @@ class MockCamera:
 
 class TestCameraService(unittest.TestCase):
 
-    def local_to_ndc(
-        self,
-        projection: OrthoProjection,
-        local_position: LocalCoords,
-        expected: NDCCoords,
-        zoom_level: ZoomLevel = 1,
-    ):
-        test_cam = MockCamera(projection)
-        test_cam.zoom_level = zoom_level
-        ndc_coords = CameraService.local_to_ndc(test_cam, local_position)
-        self.assertEqual(ndc_coords, expected)
-
     def test_local_to_ndc(self):
-        test_params: list[tuple[OrthoProjection, LocalCoords, NDCCoords, ZoomLevel]] = [
-            # Centered projection, center coords
-            (centered_projection, zero_vector, zero_vector, 1),
-            # Centered projection, corner coords
-            (centered_projection, Vector3(-400, -300, 1), Vector3(-1, -1, 1), 1),
-            # 3/4 projection, local 0 coords
-            (three_quart_projection, zero_vector, Vector3(-0.5, -0.5, 0), 1),
-            # 3/4 projection, center coords
-            (three_quart_projection, Vector3(200, 150, 0), zero_vector, 1),
-            # 3/4 projection, corner coords
-            (three_quart_projection, Vector3(-200, -150, 0), Vector3(-1, -1, 0), 1),
-            # Centered projection, center coords, zoom level 2
-            (centered_projection, zero_vector, zero_vector, 2),
-            # Centered projection, corner coords, zoom level 2
-            (centered_projection, Vector3(-200, -150, 1), Vector3(-1, -1, 1), 2),
-        ]
+        test_params: dict[
+            str, tuple[OrthoProjection, LocalCoords, NDCCoords, ZoomLevel]
+        ] = {
+            "Centered projection, center coords": (
+                centered_projection,
+                zero_vector,
+                zero_vector,
+                1,
+            ),
+            "Centered projection, corner coords": (
+                centered_projection,
+                Vector3(-400, -300, 1),
+                Vector3(-1, -1, 1),
+                1,
+            ),
+            "3/4 projection, local 0 coords": (
+                three_quart_projection,
+                zero_vector,
+                Vector3(-0.5, -0.5, 0),
+                1,
+            ),
+            "3/4 projection, center coords": (
+                three_quart_projection,
+                Vector3(200, 150, 0),
+                zero_vector,
+                1,
+            ),
+            "3/4 projection, corner coords": (
+                three_quart_projection,
+                Vector3(-200, -150, 0),
+                Vector3(-1, -1, 0),
+                1,
+            ),
+            "Centered projection, center coords, zoom level 2": (
+                centered_projection,
+                zero_vector,
+                zero_vector,
+                2,
+            ),
+            "Centered projection, corner coords, zoom level 2": (
+                centered_projection,
+                Vector3(-200, -150, 1),
+                Vector3(-1, -1, 1),
+                2,
+            ),
+        }
 
-        for params in test_params:
-            self.local_to_ndc(*params)
+        for index, (case, params) in enumerate(test_params.items()):
+            with self.subTest(case, i=index):
+                projection, local_position, expected, zoom_level = params
+                test_cam = MockCamera(projection)
+                test_cam.zoom_level = zoom_level
+                ndc_coords = CameraService.local_to_ndc(test_cam, local_position)
+                self.assertEqual(ndc_coords, expected)
 
     def ndc_to_local(
         self,

--- a/tests/test_camera_service.py
+++ b/tests/test_camera_service.py
@@ -234,91 +234,66 @@ class TestCameraService(unittest.TestCase):
                 self.assertEqual(eye_transform, expected)
 
     def test_to_world(self):
-        # Centered projection, both default transform
-        projection = OrthoProjection(Rect(-400, -300, 800, 600))
-        test_cam = MockCamera(projection)
+        shifted_pos_transform = Transform((10, 0))
+        shifted_post_rot_transform = Transform((10, 0), 90)
 
-        local_transform = Transform((0, 0), 0, (0, 0))
+        test_params: dict[
+            str, tuple[Projection, WorldTransform, LocalTransform, WorldTransform]
+        ] = {
+            "Centered projection, both default transform": (
+                centered_projection,
+                zero_transform,
+                zero_transform,
+                zero_transform,
+            ),
+            "Centered Projection, Different test position": (
+                centered_projection,
+                zero_transform,
+                shifted_pos_transform,
+                shifted_pos_transform,
+            ),
+            "Centered Projection, Different test position, rotation": (
+                centered_projection,
+                zero_transform,
+                shifted_post_rot_transform,
+                shifted_post_rot_transform,
+            ),
+            "3/4 projection, local 0 coords": (
+                three_quart_projection,
+                zero_transform,
+                zero_transform,
+                Transform((-200, -150)),
+            ),
+            "3/4 projection, counter local coords": (
+                three_quart_projection,
+                zero_transform,
+                Transform((200, 150)),
+                zero_transform,
+            ),
+            "Centered projection, off center camera, origin test transform": (
+                centered_projection,
+                Transform((100, 100)),
+                zero_transform,
+                Transform((100, 100)),
+            ),
+            "Centered projection, off center rotated camera, origin test transform": (
+                centered_projection,
+                Transform((100, 100), 90),
+                zero_transform,
+                Transform((100, 100), 90),
+            ),
+        }
 
-        world_transform = CameraService.to_world(test_cam, local_transform)
+        for index, (case, params) in enumerate(test_params.items()):
+            with self.subTest(case, i=index):
+                projection, cam_transform, local_transform, expected = params
+                test_cam = MockCamera(projection)
+                test_cam.transform.world_position = cam_transform.position
+                test_cam.transform.world_rotation = cam_transform.rotation
 
-        expected = Transform((0, 0), 0, (0, 0))
+                world_transform = CameraService.to_world(test_cam, local_transform)
 
-        self.assertEqual(world_transform, expected)
-
-        # Centered Projection, Default camera, Different test position,
-
-        local_transform = Transform((10, 0), 0, (0, 0))
-
-        world_transform = CameraService.to_world(test_cam, local_transform)
-
-        expected = Transform((10, 0), 0, (0, 0))
-
-        self.assertEqual(world_transform, expected)
-
-        # Centered Projection, Default camera, Different test position, rotation,
-
-        local_transform = Transform((10, 0), 90, (0, 0))
-
-        world_transform = CameraService.to_world(test_cam, local_transform)
-
-        expected = Transform((10, 0), 90, (0, 0))
-
-        self.assertEqual(world_transform, expected)
-
-        # 3/4 projection, local 0 coords
-
-        projection = OrthoProjection(Rect(-200, -150, 800, 600))
-
-        assert projection.far_plane.center == (200, 150)
-        test_cam.projection = projection
-
-        local_transform = Transform((0, 0), 0, (0, 0))
-
-        world_transform = CameraService.to_world(test_cam, local_transform)
-
-        expected = Transform((-200, -150), 0, (0, 0))
-
-        self.assertEqual(world_transform, expected)
-
-        # 3/4 projection, counter local coords
-
-        local_transform = Transform((200, 150), 0, (0, 0))
-
-        world_transform = CameraService.to_world(test_cam, local_transform)
-
-        expected = Transform((0, 0), 0, (0, 0))
-
-        self.assertEqual(world_transform, expected)
-
-        # Centered projection, off center camera, origin test transform
-        projection = OrthoProjection(Rect(-400, -300, 800, 600))
-
-        assert projection.far_plane.center == (0, 0)
-        test_cam.projection = projection
-
-        test_cam.transform.world_position = (100, 100)
-
-        local_transform = Transform((0, 0), 0, (0, 0))
-
-        world_transform = CameraService.to_world(test_cam, local_transform)
-
-        expected = Transform((100, 100), 0, (0, 0))
-
-        self.assertEqual(world_transform, expected)
-
-        # Centered projection, off center rotated camera, origin test transform
-
-        test_cam.transform.world_position = (100, 0)
-        test_cam.transform.world_rotation = 90
-
-        local_transform = Transform((0, 0), 0, (0, 0))
-
-        world_transform = CameraService.to_world(test_cam, local_transform)
-
-        expected = Transform((100, 0), 90, (0, 0))
-
-        self.assertEqual(world_transform, expected)
+                self.assertEqual(world_transform, expected)
 
 
 if __name__ == "__main__":

--- a/tests/test_rect_bounds.py
+++ b/tests/test_rect_bounds.py
@@ -11,32 +11,27 @@ from src.pyrite.rendering.rect_bounds import rotate_rect  # noqa:E402
 from src.pyrite.enum import Anchor  # noqa:E402
 
 
+anchor_center = Anchor((0.5, 0.5))
+anchor_75x_5y = Anchor((0.75, 0.5))
+rect = Rect(-4, -2, 8, 4)
+
+
 class TestRectBounds(unittest.TestCase):
 
     def test_rotate_rect(self):
-        # Centered anchor, 90 rotation.
-        anchor = Anchor((0.5, 0.5))
 
-        rect = Rect(-4, -2, 8, 4)
+        test_params: dict[str, tuple[Anchor, float, Rect]] = {
+            "Centered anchor, 90 rotation": (anchor_center, 90, Rect(-2, -4, 4, 8)),
+            "3/4 X, Center Y, 90 rotation": (anchor_75x_5y, 90, Rect(0, -2, 4, 8)),
+        }
 
-        rotated_rect = rotate_rect(rect, 90, anchor.get_center_offset(rect))
+        for index, (case, params) in enumerate(test_params.items()):
+            with self.subTest(case, i=index):
+                anchor, angle, expected = params
 
-        self.assertEqual(rotated_rect.left, -2)
-        self.assertEqual(rotated_rect.top, -4)
-        self.assertEqual(rotated_rect.width, 4)
-        self.assertEqual(rotated_rect.height, 8)
+                rotated_rect = rotate_rect(rect, angle, anchor.get_center_offset(rect))
 
-        # 3/4 X, Center Y, 90 rotation.
-        anchor = Anchor((0.75, 0.5))
-
-        rect = Rect(-4, -2, 8, 4)
-
-        rotated_rect = rotate_rect(rect, 90, anchor.get_center_offset(rect))
-
-        self.assertEqual(rotated_rect.left, 0)
-        self.assertEqual(rotated_rect.top, -2)
-        self.assertEqual(rotated_rect.width, 4)
-        self.assertEqual(rotated_rect.height, 8)
+                self.assertEqual(rotated_rect, expected)
 
 
 if __name__ == "__main__":

--- a/tests/test_viewport.py
+++ b/tests/test_viewport.py
@@ -2,23 +2,29 @@ from __future__ import annotations
 
 import pathlib
 import sys
-from typing import TYPE_CHECKING
+from typing import TypeAlias, TYPE_CHECKING
 import unittest
 
 from pygame import FRect, Rect
 
 if TYPE_CHECKING:
-    pass
+    from pygame.typing import Point
+
+    NDCCoords: TypeAlias = Point
+    ScreenCoords: TypeAlias = Point
 
 sys.path.append(str(pathlib.Path.cwd()))
 from src.pyrite.rendering import Viewport  # noqa:E402
 
-display_size = (600, 800)
+display_size: Point = (600, 800)
 
 
 fullscreen = FRect(-1, 1, 2, 2)
 lower_right = FRect(-1, 1, 1, 1)
+bottom_right = FRect(0, 0, 1, 1)
 upper_left = FRect(-1, 1, 1, 1)
+
+screen_center = (display_size[0] / 2, display_size[1] / 2)
 
 
 class TestViewport(unittest.TestCase):
@@ -41,65 +47,41 @@ class TestViewport(unittest.TestCase):
                 self.assertEqual(display_rect, expected_rect)
 
     def test_ndc_to_screen(self):
-        # Full screen, top left point
-        viewport_rect = FRect(-1, 1, 2, 2)
-        viewport = Viewport(viewport_rect)
-        viewport._update_display_rect(display_size)
-        ndc_coords = (-1, 1)
 
-        screen_coords = viewport.ndc_to_screen(ndc_coords)
+        test_params: dict[str, tuple[FRect, NDCCoords, ScreenCoords]] = {
+            "Full screen, top left point": (fullscreen, (-1, 1), (0, 0)),
+            "Full screen, bottom right point": (fullscreen, (1, -1), display_size),
+            "Full screen, center point": (
+                fullscreen,
+                (0, 0),
+                screen_center,
+            ),
+            "Bottomright quadrant screen, top left point": (
+                bottom_right,
+                (-1, 1),
+                screen_center,
+            ),
+            "Bottomright quadrant screen, bottom right point": (
+                bottom_right,
+                (1, -1),
+                display_size,
+            ),
+            "Bottomright quadrant screen, center point": (
+                bottom_right,
+                (0, 0),
+                (3 * display_size[0] / 4, 3 * display_size[1] / 4),
+            ),
+        }
 
-        expected_coords = (0, 0)
+        for index, (case, params) in enumerate(test_params.items()):
+            with self.subTest(case, i=index):
+                viewport_rect, ndc_coords, expected_coords = params
+                viewport = Viewport(viewport_rect)
+                viewport._update_display_rect(display_size)
 
-        self.assertEqual(screen_coords, expected_coords)
+                screen_coords = viewport.ndc_to_screen(ndc_coords)
 
-        # Full screen, bottom right point
-        ndc_coords = (1, -1)
-
-        screen_coords = viewport.ndc_to_screen(ndc_coords)
-
-        expected_coords = display_size
-
-        self.assertEqual(screen_coords, expected_coords)
-
-        # Full screen, center point
-        ndc_coords = (0, 0)
-
-        screen_coords = viewport.ndc_to_screen(ndc_coords)
-
-        expected_coords = display_size[0] / 2, display_size[1] / 2
-
-        self.assertEqual(screen_coords, expected_coords)
-
-        # Bottomright quadrant screen, top left point
-        viewport_rect = FRect(0, 0, 1, 1)
-        viewport = Viewport(viewport_rect)
-        viewport._update_display_rect(display_size)
-        ndc_coords = (-1, 1)
-
-        screen_coords = viewport.ndc_to_screen(ndc_coords)
-
-        expected_coords = display_size[0] / 2, display_size[1] / 2
-
-        self.assertEqual(screen_coords, expected_coords)
-
-        # Bottomright quadrant screen, bottom right point
-        ndc_coords = (1, -1)
-
-        screen_coords = viewport.ndc_to_screen(ndc_coords)
-
-        expected_coords = display_size
-
-        self.assertEqual(screen_coords, expected_coords)
-
-        # Bottomright quadrant screen, center point
-        ndc_coords = (0, 0)
-
-        screen_coords = viewport.ndc_to_screen(ndc_coords)
-
-        expected_coords = 3 * display_size[0] / 4, 3 * display_size[1] / 4
-
-        self.assertEqual(screen_coords, expected_coords)
+                self.assertEqual(screen_coords, expected_coords)
 
     def test_screen_to_ndc(self):
         # Full screen, top left point

--- a/tests/test_viewport.py
+++ b/tests/test_viewport.py
@@ -16,36 +16,29 @@ from src.pyrite.rendering import Viewport  # noqa:E402
 display_size = (600, 800)
 
 
+fullscreen = FRect(-1, 1, 2, 2)
+lower_right = FRect(-1, 1, 1, 1)
+upper_left = FRect(-1, 1, 1, 1)
+
+
 class TestViewport(unittest.TestCase):
 
     def test_get_subrect(self):
-        # Full screen
-        display = (600, 800)
-        viewport_rect = FRect(-1, 1, 2, 2)
 
-        display_rect = Viewport._get_subrect(viewport_rect, display)
+        test_params: dict[str, tuple[FRect, Rect]] = {
+            "Full screen": (fullscreen, Rect(0, 0, 600, 800)),
+            "Lower Right": (lower_right, Rect(0, 0, 300, 400)),
+            "Upper left": (upper_left, Rect(0, 0, 300, 400)),
+        }
 
-        expected_rect = Rect(0, 0, 600, 800)
+        for index, (case, params) in enumerate(test_params.items()):
+            with self.subTest(case, i=index):
+                display = (600, 800)
+                viewport_rect, expected_rect = params
 
-        self.assertEqual(display_rect, expected_rect)
+                display_rect = Viewport._get_subrect(viewport_rect, display)
 
-        # Lower Right
-        viewport_rect = FRect(0, 0, 1, 1)
-
-        display_rect = Viewport._get_subrect(viewport_rect, display)
-
-        expected_rect = Rect(300, 400, 300, 400)
-
-        self.assertEqual(display_rect, expected_rect)
-
-        # Upper left
-        viewport_rect = FRect(-1, 1, 1, 1)
-
-        display_rect = Viewport._get_subrect(viewport_rect, display)
-
-        expected_rect = Rect(0, 0, 300, 400)
-
-        self.assertEqual(display_rect, expected_rect)
+                self.assertEqual(display_rect, expected_rect)
 
     def test_ndc_to_screen(self):
         # Full screen, top left point

--- a/tests/test_viewport.py
+++ b/tests/test_viewport.py
@@ -84,65 +84,37 @@ class TestViewport(unittest.TestCase):
                 self.assertEqual(screen_coords, expected_coords)
 
     def test_screen_to_ndc(self):
-        # Full screen, top left point
-        viewport_rect = FRect(-1, 1, 2, 2)
-        viewport = Viewport(viewport_rect)
-        viewport._update_display_rect(display_size)
-        screen_coords = (0, 0)
 
-        ndc_coords = viewport.screen_to_ndc(screen_coords)
+        test_params: dict[str, tuple[FRect, ScreenCoords, NDCCoords]] = {
+            "Full screen, top left point": (fullscreen, (0, 0), (-1, 1)),
+            "Full screen, bottom right point": (fullscreen, display_size, (1, -1)),
+            "Full screen, center point": (fullscreen, screen_center, (0, 0)),
+            "Bottomright quadrant screen, top left point": (
+                bottom_right,
+                screen_center,
+                (-1, 1),
+            ),
+            "Bottomright quadrant screen, bottom right point": (
+                bottom_right,
+                display_size,
+                (1, -1),
+            ),
+            "Bottomright quadrant screen, center point": (
+                bottom_right,
+                (3 * display_size[0] / 4, 3 * display_size[1] / 4),
+                (0, 0),
+            ),
+        }
 
-        expected_coords = (-1, 1)
+        for index, (case, params) in enumerate(test_params.items()):
+            with self.subTest(case, i=index):
+                viewport_rect, screen_coords, expected_coords = params
+                viewport = Viewport(viewport_rect)
+                viewport._update_display_rect(display_size)
 
-        self.assertEqual(ndc_coords, expected_coords)
+                ndc_coords = viewport.screen_to_ndc(screen_coords)
 
-        # Full screen, bottom right point
-        screen_coords = display_size
-
-        ndc_coords = viewport.screen_to_ndc(screen_coords)
-
-        expected_coords = (1, -1)
-
-        self.assertEqual(ndc_coords, expected_coords)
-
-        # Full screen, center point
-        screen_coords = display_size[0] / 2, display_size[1] / 2
-
-        ndc_coords = viewport.screen_to_ndc(screen_coords)
-
-        expected_coords = (0, 0)
-
-        self.assertEqual(ndc_coords, expected_coords)
-
-        # Bottomright quadrant screen, top left point
-        viewport_rect = FRect(0, 0, 1, 1)
-        viewport = Viewport(viewport_rect)
-        viewport._update_display_rect(display_size)
-        screen_coords = display_size[0] / 2, display_size[1] / 2
-
-        ndc_coords = viewport.screen_to_ndc(screen_coords)
-
-        expected_coords = (-1, 1)
-
-        self.assertEqual(ndc_coords, expected_coords)
-
-        # Bottomright quadrant screen, bottom right point
-        screen_coords = display_size
-
-        ndc_coords = viewport.screen_to_ndc(screen_coords)
-
-        expected_coords = (1, -1)
-
-        self.assertEqual(ndc_coords, expected_coords)
-
-        # Bottomright quadrant screen, center point
-        screen_coords = 3 * display_size[0] / 4, 3 * display_size[1] / 4
-
-        ndc_coords = viewport.screen_to_ndc(screen_coords)
-
-        expected_coords = (0, 0)
-
-        self.assertEqual(ndc_coords, expected_coords)
+                self.assertEqual(ndc_coords, expected_coords)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Exactly what is says on the tin.

This makes the tests more readable and easier to modify/expand as cases changes or are added.