### PR TITLE
Modernize generics

### DIFF
--- a/src/pyrite/core/render_system.py
+++ b/src/pyrite/core/render_system.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 import bisect
 from collections.abc import Iterable
-from typing import cast, Self, TypeAlias, TYPE_CHECKING
+from typing import cast, Self, TYPE_CHECKING
 from weakref import WeakSet
 
 from pygame import Surface
@@ -18,8 +18,8 @@ if TYPE_CHECKING:
     from ..types import Camera, Renderable
     from ..types.debug_renderer import DebugRenderer
 
-    LayerDict: TypeAlias = dict[Camera, list[Renderable]]
-    RenderQueue: TypeAlias = dict[Layer, LayerDict]
+    type LayerDict = dict[Camera, list[Renderable]]
+    type RenderQueue = dict[Layer, LayerDict]
 
 EMPTY_LAYER_SET: set[Renderable] = set()
 

--- a/src/pyrite/core/system_manager.py
+++ b/src/pyrite/core/system_manager.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 import bisect
-from typing import cast, Self, TYPE_CHECKING, TypeVar
+from typing import cast, Self, TYPE_CHECKING
 from weakref import WeakSet
 
 from ..types.system import System
@@ -10,9 +10,6 @@ from ..types.system import System
 if TYPE_CHECKING:
     from collections.abc import Iterable
     from pygame import Event
-
-
-SystemType = TypeVar("SystemType", bound=System)
 
 
 _active_system_manager: SystemManager
@@ -114,7 +111,9 @@ class SystemManager(ABC):
         pass
 
     @abstractmethod
-    def get_system(self, system_type: type[SystemType]) -> SystemType | None:
+    def get_system[SystemType: System](
+        self, system_type: type[SystemType]
+    ) -> SystemType | None:
         """
         Returns the instance that matches the system type.
 
@@ -124,7 +123,9 @@ class SystemManager(ABC):
         pass
 
     @abstractmethod
-    def remove_system(self, system_type: type[SystemType]) -> SystemType:
+    def remove_system[SystemType: System](
+        self, system_type: type[SystemType]
+    ) -> SystemType:
         """
         Removes a system instance from all parts of the system manager,
         based on the system type.
@@ -230,13 +231,17 @@ class DefaultSystemManager(SystemManager):
         if system.__class__ not in self.systems:  # I don't this is needed?
             self.systems.update({system.__class__: system})
 
-    def get_system(self, system_type: type[SystemType]) -> SystemType | None:
+    def get_system[SystemType: System](
+        self, system_type: type[SystemType]
+    ) -> SystemType | None:
         system = self.systems.get(system_type)
         if system is not None:
             system = cast(SystemType, system)
         return system
 
-    def remove_system(self, system_type: type[SystemType]) -> SystemType:
+    def remove_system[SystemType: System](
+        self, system_type: type[SystemType]
+    ) -> SystemType:
         system = self.systems.pop(system_type)
         self.active_systems.discard(system)
         if system is not None:

--- a/src/pyrite/events/instance_event.py
+++ b/src/pyrite/events/instance_event.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from abc import abstractmethod
 from collections.abc import Callable
 from functools import singledispatchmethod
-from typing import Any, Generic, TypeVar, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 from weakref import ref, WeakKeyDictionary
 
 from ..types.instance_event import InstanceEvent
@@ -14,8 +14,6 @@ from ..utils import threading
 if TYPE_CHECKING:
     pass
 
-T = TypeVar("T")
-
 
 class _Sentinel:
 
@@ -25,7 +23,7 @@ class _Sentinel:
 SENTINEL = _Sentinel()
 
 
-class BaseInstanceEvent(InstanceEvent, Generic[T]):
+class BaseInstanceEvent[T](InstanceEvent):
     """
     Events that are bound to an instance of an object. They accumulate listeners, which
     respond when the event fires.

--- a/src/pyrite/rendering/sprite_renderer/sprite_renderer.py
+++ b/src/pyrite/rendering/sprite_renderer/sprite_renderer.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import abstractmethod
-from typing import cast, TypeAlias, TYPE_CHECKING
+from typing import cast, TYPE_CHECKING
 from weakref import WeakKeyDictionary
 
 import pygame
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from ...types import TransformLike
     from ... import Transform
 
-    SpriteData: TypeAlias = tuple[Surface, Transform]
+    type SpriteData = tuple[Surface, Transform]
 
 
 class SpriteRenderer(Renderer[Sprite, Camera]):

--- a/src/pyrite/services/bounds_service/bounds_service.py
+++ b/src/pyrite/services/bounds_service/bounds_service.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import abstractmethod
-from typing import TypeAlias, TYPE_CHECKING
+from typing import TYPE_CHECKING
 from weakref import WeakKeyDictionary
 
 from ...types.service import Service
@@ -9,7 +9,7 @@ from ...types.service import Service
 if TYPE_CHECKING:
     from ...types import CullingBounds, Renderable, TransformLike
 
-    BoundsData: TypeAlias = tuple[CullingBounds, TransformLike]
+    type BoundsData = tuple[CullingBounds, TransformLike]
 
 
 class BoundsService(Service):

--- a/src/pyrite/services/transform_service/transform_service.py
+++ b/src/pyrite/services/transform_service/transform_service.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import abstractmethod
-from typing import TypeAlias, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 from weakref import WeakKeyDictionary, WeakSet
 
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from pygame.typing import Point
     from ...transform import Transform, TransformComponent
 
-    NodeDict: TypeAlias = WeakKeyDictionary[
+    type NodeDict = WeakKeyDictionary[
         TransformComponent, WeakTreeNode[TransformComponent]
     ]
 

--- a/src/pyrite/sprite/spritesheet.py
+++ b/src/pyrite/sprite/spritesheet.py
@@ -4,7 +4,7 @@ from abc import ABC, abstractmethod
 
 from collections.abc import Sequence
 import pathlib
-from typing import Generic, TypeAlias, TypeVar, TYPE_CHECKING
+from typing import TypeAlias, TypeVar, TYPE_CHECKING
 
 from pygame import Rect
 
@@ -33,7 +33,7 @@ def default_decoder(sprite_map_file: TextIO) -> RectDict[str]:
     return sprites
 
 
-class SpriteMap(ABC, Generic[MapKeyT]):
+class SpriteMap[MapKeyT](ABC):
     """
     A dictionary of rects for getting the subsurfaces for a spritesheet.
     """
@@ -163,7 +163,7 @@ class SimpleSpriteMap(SpriteMap[Sequence[int]]):
         return self._map[row][column]
 
 
-class DictSpriteMap(SpriteMap[MapKeyT]):
+class DictSpriteMap[MapKeyT](SpriteMap):
     """
     Version of SpriteMap that uses a dictionary of Rects. Can be generated from file.
     """
@@ -227,7 +227,7 @@ class DictSpriteMap(SpriteMap[MapKeyT]):
         return self._map[key]
 
 
-class SpriteSheet(Generic[MapKeyT]):
+class SpriteSheet[MapKeyT]:
     """
     A tool that can select subsections of a larger surface for display.
     Useful for animations, or otherwise collecting multiple images

--- a/src/pyrite/sprite/spritesheet.py
+++ b/src/pyrite/sprite/spritesheet.py
@@ -4,7 +4,7 @@ from abc import ABC, abstractmethod
 
 from collections.abc import Sequence
 import pathlib
-from typing import TypeAlias, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 from pygame import Rect
 
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from pygame.typing import Point
 
     type RectDict[MapKeyT] = dict[MapKeyT, Rect]
-    DecoderFunction: TypeAlias = Callable[[TextIO], RectDict | None]
+    type DecoderFunction = Callable[[TextIO], RectDict | None]
 
 
 def default_decoder(sprite_map_file: TextIO) -> RectDict[str]:

--- a/src/pyrite/sprite/spritesheet.py
+++ b/src/pyrite/sprite/spritesheet.py
@@ -4,11 +4,9 @@ from abc import ABC, abstractmethod
 
 from collections.abc import Sequence
 import pathlib
-from typing import TypeAlias, TypeVar, TYPE_CHECKING
+from typing import TypeAlias, TYPE_CHECKING
 
 from pygame import Rect
-
-MapKeyT = TypeVar("MapKeyT")
 
 if TYPE_CHECKING:
     import os
@@ -17,7 +15,7 @@ if TYPE_CHECKING:
     from pygame import Surface
     from pygame.typing import Point
 
-    RectDict: TypeAlias = dict[MapKeyT, Rect]
+    type RectDict[MapKeyT] = dict[MapKeyT, Rect]
     DecoderFunction: TypeAlias = Callable[[TextIO], RectDict | None]
 
 

--- a/src/pyrite/types/instance_event.py
+++ b/src/pyrite/types/instance_event.py
@@ -2,14 +2,11 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from functools import singledispatchmethod
-from typing import Generic, TypeVar, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from collections.abc import Callable
     from typing import Any
-
-
-T = TypeVar("T")
 
 
 class _Sentinel:
@@ -20,7 +17,7 @@ class _Sentinel:
 SENTINEL = _Sentinel()
 
 
-class InstanceEvent(ABC, Generic[T]):
+class InstanceEvent[T](ABC):
     """
     Events that are bound to an instance of an object. They accumulate listeners, which
     respond when the event fires.

--- a/src/pyrite/types/renderer.py
+++ b/src/pyrite/types/renderer.py
@@ -1,16 +1,13 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Generic, TypeVar, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     pass
 
-RenderableTypeT = TypeVar("RenderableTypeT")
-RenderTargetT = TypeVar("RenderTargetT")
 
-
-class Renderer(ABC, Generic[RenderableTypeT, RenderTargetT]):
+class Renderer[RenderableTypeT, RenderTargetT](ABC):
 
     @abstractmethod
     def render(
@@ -26,10 +23,7 @@ class Renderer(ABC, Generic[RenderableTypeT, RenderTargetT]):
         pass
 
 
-ProvidedRendererT = TypeVar("ProvidedRendererT", bound=Renderer)
-
-
-class RendererProvider(ABC, Generic[ProvidedRendererT]):
+class RendererProvider[ProvidedRendererT: Renderer](ABC):
     """
     Accessor class for a given renderer. Delegates methods to the renderer instance,
     providing an access point to the users of that renderer while allowing the instance

--- a/src/pyrite/types/service.py
+++ b/src/pyrite/types/service.py
@@ -1,15 +1,13 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Generic, TypeVar, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     pass
 
-ServiceType = TypeVar("ServiceType")
 
-
-class Service(ABC, Generic[ServiceType]):
+class Service[ServiceType](ABC):
     """
     Controls data and provides methods for various objects in a way that is runtime
     swappable. Objects use the appropriate ServiceProvider to access a service.
@@ -28,10 +26,7 @@ class Service(ABC, Generic[ServiceType]):
         """
 
 
-ProvidedService = TypeVar("ProvidedService", bound=Service)
-
-
-class ServiceProvider(ABC, Generic[ProvidedService]):
+class ServiceProvider[ProvidedService: Service](ABC):
     """
     Class for providing access to a given service. The ServiceProvider will delegate
     out to the active version of the service. This way, services are runtime swappable,

--- a/tests/test_camera_service.py
+++ b/tests/test_camera_service.py
@@ -7,11 +7,10 @@ import unittest
 from pygame import Rect, Vector3
 
 if TYPE_CHECKING:
-    from typing import TypeAlias
 
-    LocalCoords: TypeAlias = Vector3
-    NDCCoords: TypeAlias = Vector3
-    ZoomLevel: TypeAlias = float
+    type LocalCoords = Vector3
+    type NDCCoords = Vector3
+    type ZoomLevel = float
 
 
 sys.path.append(str(pathlib.Path.cwd()))
@@ -22,9 +21,9 @@ from src.pyrite.types.camera import CameraBase  # noqa:E402
 from src.pyrite.transform import TransformComponent, Transform  # noqa: E402
 
 if TYPE_CHECKING:
-    WorldTransform: TypeAlias = Transform
-    LocalTransform: TypeAlias = Transform
-    EyeTransform: TypeAlias = Transform
+    type WorldTransform = Transform
+    type LocalTransform = Transform
+    type EyeTransform = Transform
 
 
 centered_projection = OrthoProjection(Rect(-400, -300, 800, 600))

--- a/tests/test_camera_service.py
+++ b/tests/test_camera_service.py
@@ -4,11 +4,11 @@ import unittest
 
 from pygame import Rect, Vector3
 
-from src.pyrite.services import CameraService
-from src.pyrite.rendering import OrthoProjection
-from src.pyrite.types.projection import Projection
-from src.pyrite.types.camera import CameraBase
-from src.pyrite.transform import TransformComponent, Transform
+from pyrite.services import CameraService
+from pyrite.rendering import OrthoProjection
+from pyrite.types.projection import Projection
+from pyrite.types.camera import CameraBase
+from pyrite.transform import TransformComponent, Transform
 
 if TYPE_CHECKING:
 

--- a/tests/test_camera_service.py
+++ b/tests/test_camera_service.py
@@ -1,26 +1,20 @@
 from __future__ import annotations
-import pathlib
-import sys
 from typing import cast, TYPE_CHECKING
 import unittest
 
 from pygame import Rect, Vector3
+
+from src.pyrite.services import CameraService
+from src.pyrite.rendering import OrthoProjection
+from src.pyrite.types.projection import Projection
+from src.pyrite.types.camera import CameraBase
+from src.pyrite.transform import TransformComponent, Transform
 
 if TYPE_CHECKING:
 
     type LocalCoords = Vector3
     type NDCCoords = Vector3
     type ZoomLevel = float
-
-
-sys.path.append(str(pathlib.Path.cwd()))
-from src.pyrite.services import CameraService  # noqa:E402
-from src.pyrite.rendering import OrthoProjection  # noqa: E402
-from src.pyrite.types.projection import Projection  # noqa:E402
-from src.pyrite.types.camera import CameraBase  # noqa:E402
-from src.pyrite.transform import TransformComponent, Transform  # noqa: E402
-
-if TYPE_CHECKING:
     type WorldTransform = Transform
     type LocalTransform = Transform
     type EyeTransform = Transform

--- a/tests/test_viewport.py
+++ b/tests/test_viewport.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pathlib
 import sys
-from typing import TypeAlias, TYPE_CHECKING
+from typing import TYPE_CHECKING
 import unittest
 
 from pygame import FRect, Rect
@@ -10,8 +10,8 @@ from pygame import FRect, Rect
 if TYPE_CHECKING:
     from pygame.typing import Point
 
-    NDCCoords: TypeAlias = Point
-    ScreenCoords: TypeAlias = Point
+    type NDCCoords = Point
+    type ScreenCoords = Point
 
 sys.path.append(str(pathlib.Path.cwd()))
 from src.pyrite.rendering import Viewport  # noqa:E402

--- a/tests/test_viewport.py
+++ b/tests/test_viewport.py
@@ -1,20 +1,17 @@
 from __future__ import annotations
 
-import pathlib
-import sys
 from typing import TYPE_CHECKING
 import unittest
 
 from pygame import FRect, Rect
+
+from pyrite.rendering import Viewport
 
 if TYPE_CHECKING:
     from pygame.typing import Point
 
     type NDCCoords = Point
     type ScreenCoords = Point
-
-sys.path.append(str(pathlib.Path.cwd()))
-from src.pyrite.rendering import Viewport  # noqa:E402
 
 display_size: Point = (600, 800)
 


### PR DESCRIPTION
Removes all of the instances of the old-type syntax for generics and type aliases, and replaces it with all the modern form of the syntax