### PR TITLE
Rename base classes

### DIFF
--- a/src/pyrite/__init__.py
+++ b/src/pyrite/__init__.py
@@ -38,7 +38,7 @@ Camera = pyrite._camera.camera.BaseCamera
 ChaseCamera = pyrite._camera.chase_camera.ChaseCamera
 
 Renderable = pyrite._rendering.base_renderable.BaseRenderable
-Sprite = pyrite._sprite.sprite.Sprite
+Sprite = pyrite._sprite.sprite.BaseSprite
 SpriteSheet = pyrite._sprite.spritesheet.SpriteSheet
 System = pyrite._systems.base_system.BaseSystem
 

--- a/src/pyrite/__init__.py
+++ b/src/pyrite/__init__.py
@@ -34,7 +34,7 @@ ColliderComponent = pyrite._physics.collider_component.ColliderComponent
 KinematicComponent = pyrite._physics.kinematic_component.KinematicComponent
 RigidbodyComponent = pyrite._physics.rigidbody_component.RigidbodyComponent
 
-Camera = pyrite._camera.camera.Camera
+Camera = pyrite._camera.camera.BaseCamera
 ChaseCamera = pyrite._camera.chase_camera.ChaseCamera
 
 Renderable = pyrite._rendering.base_renderable.BaseRenderable

--- a/src/pyrite/__init__.py
+++ b/src/pyrite/__init__.py
@@ -24,7 +24,7 @@ Game = pyrite.game.Game
 AsyncGame = pyrite.game.AsyncGame
 get_game_instance = pyrite.game.get_game_instance
 
-Entity = pyrite._entity.entity.BaseEntity
+BaseEntity = pyrite._entity.entity.BaseEntity
 
 RenderLayers = pyrite.enum.RenderLayers
 AnchorPoint = pyrite.enum.AnchorPoint

--- a/src/pyrite/_camera/camera.py
+++ b/src/pyrite/_camera/camera.py
@@ -9,7 +9,7 @@ from pyrite.events import OnEnable, OnDisable
 from pyrite._rendering.camera_renderer import CameraRendererProvider as CameraRenderer
 from pyrite._rendering.viewport import Viewport
 from pyrite._transform.transform_component import TransformComponent
-from pyrite._types.camera import CameraBase
+from pyrite._types.camera import Camera as CameraBase
 from pyrite._types.renderable import Renderable
 
 if TYPE_CHECKING:

--- a/src/pyrite/_camera/camera.py
+++ b/src/pyrite/_camera/camera.py
@@ -9,7 +9,7 @@ from pyrite.events import OnEnable, OnDisable
 from pyrite._rendering.camera_renderer import CameraRendererProvider as CameraRenderer
 from pyrite._rendering.viewport import Viewport
 from pyrite._transform.transform_component import TransformComponent
-from pyrite._types.camera import Camera as CameraBase
+from pyrite._types.camera import Camera
 from pyrite._types.renderable import Renderable
 
 if TYPE_CHECKING:
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
     from pyrite._transform.transform import Transform
 
 
-class Camera(CameraBase):
+class BaseCamera(Camera):
     """
     Object for rendering a view to the display.
 

--- a/src/pyrite/_camera/chase_camera.py
+++ b/src/pyrite/_camera/chase_camera.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
-from pyrite._camera.camera import Camera
+from pyrite._camera.camera import BaseCamera
 from pyrite._entity.entity import BaseEntity as Entity
 
 from pygame import Vector2
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
     from pygame.typing import Point
 
 
-class ChaseCamera(Entity, Camera):
+class ChaseCamera(Entity, BaseCamera):
 
     def __init__(
         self,
@@ -61,7 +61,7 @@ class ChaseCamera(Entity, Camera):
         :param enabled: Whether the Renderable will be drawn to the screen,
         defaults to True
         """
-        Camera.__init__(
+        BaseCamera.__init__(
             self,
             projection,
             position,
@@ -85,14 +85,14 @@ class ChaseCamera(Entity, Camera):
 
     @property
     def enabled(self) -> bool:
-        assert Camera.enabled.fget
-        return Camera.enabled.fget(self)
+        assert BaseCamera.enabled.fget
+        return BaseCamera.enabled.fget(self)
 
     @enabled.setter
     def enabled(self, enabled: bool) -> None:
-        assert Camera.enabled.fset
+        assert BaseCamera.enabled.fset
         assert Entity.enabled.fset
-        Camera.enabled.fset(self, enabled)
+        BaseCamera.enabled.fset(self, enabled)
         Entity.enabled.fset(self, enabled)
 
     def post_update(self, delta_time: float) -> None:

--- a/src/pyrite/_camera/chase_camera.py
+++ b/src/pyrite/_camera/chase_camera.py
@@ -4,7 +4,7 @@ from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 from pyrite._camera.camera import BaseCamera
-from pyrite._entity.entity import BaseEntity as Entity
+from pyrite._entity.entity import BaseEntity
 
 from pygame import Vector2
 
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
     from pygame.typing import Point
 
 
-class ChaseCamera(Entity, BaseCamera):
+class ChaseCamera(BaseEntity, BaseCamera):
 
     def __init__(
         self,
@@ -70,7 +70,7 @@ class ChaseCamera(Entity, BaseCamera):
             layer_mask,
             enabled,
         )
-        Entity.__init__(
+        BaseEntity.__init__(
             self,
             enabled,
         )
@@ -91,9 +91,9 @@ class ChaseCamera(Entity, BaseCamera):
     @enabled.setter
     def enabled(self, enabled: bool) -> None:
         assert BaseCamera.enabled.fset
-        assert Entity.enabled.fset
+        assert BaseEntity.enabled.fset
         BaseCamera.enabled.fset(self, enabled)
-        Entity.enabled.fset(self, enabled)
+        BaseEntity.enabled.fset(self, enabled)
 
     def post_update(self, delta_time: float) -> None:
         if not self.target:

--- a/src/pyrite/_physics/collider_component.py
+++ b/src/pyrite/_physics/collider_component.py
@@ -11,13 +11,13 @@ from pyrite.constants import MASK_ALL
 from pyrite.events import OnSeparate, OnTouch, WhileTouching
 from pyrite._physics.rigidbody_component import RigidbodyComponent
 from pyrite._services.physics_service import PhysicsServiceProvider as PhysicsService
-from pyrite._component.component import BaseComponent as Component
+from pyrite._component.component import BaseComponent
 
 if TYPE_CHECKING:
     from pyrite._types.shape import Shape
 
 
-class ColliderComponent(Component):
+class ColliderComponent(BaseComponent):
     """
     Component that manages collision shapes for a RigidbodyComponent.
 

--- a/src/pyrite/_physics/kinematic_component.py
+++ b/src/pyrite/_physics/kinematic_component.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any
 
 from pygame import Vector2
 
-from pyrite._component.component import BaseComponent as Component
+from pyrite._component.component import BaseComponent
 from pyrite._physics.rigidbody_component import RigidbodyComponent
 from pyrite.utils import point_to_tuple
 
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from pygame.typing import Point
 
 
-class KinematicComponent(Component):
+class KinematicComponent(BaseComponent):
     """
     A component that ties into the kinematic attributes of an object's
     RigidbodyComponent.

--- a/src/pyrite/_physics/rigidbody_component.py
+++ b/src/pyrite/_physics/rigidbody_component.py
@@ -8,7 +8,7 @@ from pygame import Vector2
 from pymunk import Body
 
 from pyrite._transform.transform_component import TransformComponent
-from pyrite._component.component import BaseComponent as Component
+from pyrite._component.component import BaseComponent
 from pyrite._services.physics_service import PhysicsServiceProvider as PhysicsService
 
 if TYPE_CHECKING:
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     BodyType: TypeAlias = int
 
 
-class RigidbodyComponent(Component):
+class RigidbodyComponent(BaseComponent):
     """
     Associates an owner object with a physics body.
 

--- a/src/pyrite/_rendering/camera_renderer/__init__.py
+++ b/src/pyrite/_rendering/camera_renderer/__init__.py
@@ -6,7 +6,7 @@ from pyrite._rendering.camera_renderer.camera_renderer import (
     CameraRenderer,
     DefaultCameraRenderer,
 )
-from pyrite._types.camera import CameraBase as Camera
+from pyrite._types.camera import Camera
 from pyrite._types.renderer import RendererProvider
 
 if TYPE_CHECKING:

--- a/src/pyrite/_rendering/camera_renderer/camera_renderer.py
+++ b/src/pyrite/_rendering/camera_renderer/camera_renderer.py
@@ -7,7 +7,7 @@ import pygame
 
 from pyrite._services.camera_service import CameraServiceProvider as CameraService
 from pyrite._services.camera_service import DefaultCameraService
-from pyrite._types.camera import CameraBase as Camera
+from pyrite._types.camera import Camera
 from pyrite._types.renderer import Renderer
 from pyrite._types.protocols import RenderTarget
 

--- a/src/pyrite/_rendering/render_texture.py
+++ b/src/pyrite/_rendering/render_texture.py
@@ -4,7 +4,7 @@ from typing import cast, TYPE_CHECKING
 
 from pygame import Rect, Surface
 
-from pyrite._component.component import BaseComponent as Component
+from pyrite._component.component import BaseComponent
 from pyrite._types.protocols import HasTexture
 
 if TYPE_CHECKING:
@@ -56,7 +56,7 @@ class RenderTexture:
         return Surface(size)
 
 
-class RenderTextureComponent(Component):
+class RenderTextureComponent(BaseComponent):
     """
     Special component for sprites and sprite-like objects. Automatically updates the
     object's texture to the assigned rendertexture, and ensures it is redrawn to update.

--- a/src/pyrite/_rendering/sprite_renderer/__init__.py
+++ b/src/pyrite/_rendering/sprite_renderer/__init__.py
@@ -7,7 +7,7 @@ from pyrite._rendering.sprite_renderer.sprite_renderer import (
     SpriteRenderer,
     DefaultSpriteRenderer,
 )
-from pyrite._types.camera import CameraBase as Camera
+from pyrite._types.camera import Camera
 from pyrite._types.renderer import RendererProvider
 
 

--- a/src/pyrite/_rendering/sprite_renderer/sprite_renderer.py
+++ b/src/pyrite/_rendering/sprite_renderer/sprite_renderer.py
@@ -9,7 +9,7 @@ from pygame import Surface
 
 from pyrite._services.camera_service import CameraServiceProvider as CameraService
 from pyrite._services.camera_service.camera_service import DefaultCameraService
-from pyrite._types.camera import CameraBase as Camera
+from pyrite._types.camera import Camera
 from pyrite._types.renderer import Renderer
 from pyrite._types.sprite import BaseSprite as Sprite
 

--- a/src/pyrite/_rendering/sprite_renderer/sprite_renderer.py
+++ b/src/pyrite/_rendering/sprite_renderer/sprite_renderer.py
@@ -11,7 +11,7 @@ from pyrite._services.camera_service import CameraServiceProvider as CameraServi
 from pyrite._services.camera_service.camera_service import DefaultCameraService
 from pyrite._types.camera import Camera
 from pyrite._types.renderer import Renderer
-from pyrite._types.sprite import BaseSprite as Sprite
+from pyrite._types.sprite import Sprite
 
 if TYPE_CHECKING:
     from pyrite._types.protocols import TransformLike

--- a/src/pyrite/_services/camera_service/__init__.py
+++ b/src/pyrite/_services/camera_service/__init__.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from pygame import Vector3
 
     from pyrite._transform.transform import Transform
-    from pyrite._types.camera import CameraBase as Camera
+    from pyrite._types.camera import Camera
     from pyrite._types.view_bounds import CameraViewBounds
     from pyrite._rendering.viewport import Viewport
 

--- a/src/pyrite/_services/camera_service/camera_service.py
+++ b/src/pyrite/_services/camera_service/camera_service.py
@@ -13,7 +13,7 @@ from pyrite._types.service import Service
 if TYPE_CHECKING:
     from pygame import Rect
     from pygame.typing import Point
-    from pyrite._types.camera import CameraBase as Camera
+    from pyrite._types.camera import Camera
     from pyrite._transform.transform import Transform
     from pyrite._types.view_bounds import CameraViewBounds
     from pyrite._rendering.viewport import Viewport

--- a/src/pyrite/_sprite/sprite.py
+++ b/src/pyrite/_sprite/sprite.py
@@ -14,7 +14,7 @@ from pyrite._types.sprite import BaseSprite
 if typing.TYPE_CHECKING:
     from pygame import Surface, Vector2
     from pygame.typing import Point
-    from pyrite._types.camera import CameraBase as Camera
+    from pyrite._types.camera import Camera
     from pyrite._types.bounds import CullingBounds
     from pyrite._types.protocols import TransformLike
     from pyrite.enum import Layer, Anchor

--- a/src/pyrite/_sprite/sprite.py
+++ b/src/pyrite/_sprite/sprite.py
@@ -8,7 +8,7 @@ from pyrite._rendering.base_renderable import BaseRenderable as Renderable
 from pyrite._rendering.sprite_renderer import SpriteRendererProvider as SpriteRenderer
 from pyrite._services.bounds_service import BoundsServiceProvider as BoundsService
 from pyrite._transform.transform_component import TransformComponent
-from pyrite._types.sprite import BaseSprite
+from pyrite._types.sprite import Sprite
 
 
 if typing.TYPE_CHECKING:
@@ -20,7 +20,7 @@ if typing.TYPE_CHECKING:
     from pyrite.enum import Layer, Anchor
 
 
-class Sprite(BaseSprite, Renderable):
+class BaseSprite(Sprite, Renderable):
     """
     A basic renderable with a world position and a surface to display.
     """

--- a/src/pyrite/_transform/transform_component.py
+++ b/src/pyrite/_transform/transform_component.py
@@ -4,7 +4,7 @@ from typing import Any, TYPE_CHECKING
 
 from pygame import Vector2
 
-from pyrite._component.component import BaseComponent as Component
+from pyrite._component.component import BaseComponent
 from pyrite._transform.transform import Transform
 from pyrite._services.transform_service import (
     TransformServiceProvider as TransformService,
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from pygame.typing import Point
 
 
-class TransformComponent(Component):
+class TransformComponent(BaseComponent):
 
     def __init__(
         self,

--- a/src/pyrite/_types/camera.py
+++ b/src/pyrite/_types/camera.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
     from pyrite._transform.transform_component import TransformComponent
 
 
-class CameraBase(ABC):
+class Camera(ABC):
     """
     Defines the important attributes of a camera for the sake of drawing onto its
     surface.

--- a/src/pyrite/_types/debug_renderer.py
+++ b/src/pyrite/_types/debug_renderer.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
-    from pyrite._types.camera import CameraBase as Camera
+    from pyrite._types.camera import Camera
     from pyrite.core.render_system import RenderQueue
 
 

--- a/src/pyrite/_types/renderable.py
+++ b/src/pyrite/_types/renderable.py
@@ -4,7 +4,7 @@ from abc import abstractmethod, ABC
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from pyrite._types.camera import CameraBase as Camera
+    from pyrite._types.camera import Camera
     from pyrite._types.bounds import CullingBounds
     from pyrite.enum import Layer
     from pyrite.events import OnEnable as EventOnEnable

--- a/src/pyrite/_types/sprite.py
+++ b/src/pyrite/_types/sprite.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from pyrite.transform import TransformComponent
 
 
-class BaseSprite(Renderable):
+class Sprite(Renderable):
 
     anchor: Anchor
     transform: TransformComponent

--- a/src/pyrite/camera.py
+++ b/src/pyrite/camera.py
@@ -1,5 +1,5 @@
 import pyrite._camera.camera
 import pyrite._camera.chase_camera
 
-Camera = pyrite._camera.camera.Camera
+Camera = pyrite._camera.camera.BaseCamera
 ChaseCamera = pyrite._camera.chase_camera.ChaseCamera

--- a/src/pyrite/component.py
+++ b/src/pyrite/component.py
@@ -1,3 +1,3 @@
 import pyrite._component.component
 
-Component = pyrite._component.component.BaseComponent
+BaseComponent = pyrite._component.component.BaseComponent

--- a/src/pyrite/core/render_system.py
+++ b/src/pyrite/core/render_system.py
@@ -15,7 +15,7 @@ from pyrite._services.camera_service import CameraServiceProvider as CameraServi
 
 if TYPE_CHECKING:
     from pyrite.enum import Layer
-    from pyrite._types.camera import CameraBase as Camera
+    from pyrite._types.camera import Camera
     from pyrite._types.renderable import Renderable
     from pyrite._types.debug_renderer import DebugRenderer
 

--- a/src/pyrite/debug/bounds_renderer.py
+++ b/src/pyrite/debug/bounds_renderer.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterable
     from pygame.typing import ColorLike
     from pyrite.core.render_system import RenderQueue
-    from pyrite._types.camera import CameraBase
+    from pyrite._types.camera import Camera
 
 
 class BoundsRenderer(DebugRenderer):
@@ -22,7 +22,7 @@ class BoundsRenderer(DebugRenderer):
         self.color = Color(draw_color)
         self.font = pygame.font.Font()
 
-    def draw_to_screen(self, cameras: Iterable[CameraBase], render_queue: RenderQueue):
+    def draw_to_screen(self, cameras: Iterable[Camera], render_queue: RenderQueue):
         for layer in RenderLayers._layers:
             layer_dict = render_queue.get(layer, {})
             for renderables in layer_dict.values():

--- a/src/pyrite/debug/collider_renderer.py
+++ b/src/pyrite/debug/collider_renderer.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterable, Sequence
     from pygame.typing import ColorLike, Point
     from pyrite.core.render_system import RenderQueue
-    from pyrite._types.camera import CameraBase
+    from pyrite._types.camera import Camera
 
 
 class ColliderRenderer(DebugRenderer):
@@ -23,9 +23,7 @@ class ColliderRenderer(DebugRenderer):
         self.color = Color(draw_color)
         self.font = pygame.font.Font()
 
-    def draw_circle(
-        self, cameras: Iterable[CameraBase], position: Point, radius: float
-    ):
+    def draw_circle(self, cameras: Iterable[Camera], position: Point, radius: float):
         for camera in cameras:
             for viewport in camera.get_viewports():
                 draw.circle(
@@ -38,14 +36,14 @@ class ColliderRenderer(DebugRenderer):
                 )
 
     def draw_poly(
-        self, cameras: Iterable[CameraBase], position: Point, points: Sequence[Point]
+        self, cameras: Iterable[Camera], position: Point, points: Sequence[Point]
     ):
         points = [(position[0] + point[0], position[1] + point[1]) for point in points]
         for camera in cameras:
             for viewport in camera.get_viewports():
                 draw.polygon(camera, viewport, self.color, points, width=1)
 
-    def draw_to_screen(self, cameras: Iterable[CameraBase], render_queue: RenderQueue):
+    def draw_to_screen(self, cameras: Iterable[Camera], render_queue: RenderQueue):
 
         for component in RigidbodyComponent.get_instances().values():
             pos = component.body.position

--- a/src/pyrite/draw.py
+++ b/src/pyrite/draw.py
@@ -13,7 +13,7 @@ from pygame import Rect
 from pyrite._services.camera_service import CameraServiceProvider as CameraService
 
 if TYPE_CHECKING:
-    from pyrite._types.camera import CameraBase as Camera
+    from pyrite._types.camera import Camera
     from pyrite._rendering.viewport import Viewport
     from pygame.typing import ColorLike, Point
 

--- a/src/pyrite/entity.py
+++ b/src/pyrite/entity.py
@@ -1,3 +1,3 @@
 import pyrite._entity.entity
 
-Entity = pyrite._entity.entity.BaseEntity
+BaseEntity = pyrite._entity.entity.BaseEntity

--- a/src/pyrite/game.py
+++ b/src/pyrite/game.py
@@ -13,7 +13,7 @@ from pyrite.core.render_system import RenderSystem, RenderManager
 from pyrite.core.rate_settings import RateSettings
 from pyrite.core.system_manager import SystemManager
 
-from pyrite._camera.camera import Camera
+from pyrite._camera.camera import BaseCamera
 from pyrite._rendering.ortho_projection import OrthoProjection
 from pyrite._rendering.viewport import Viewport
 from pyrite._services.camera_service import CameraServiceProvider as CameraService
@@ -143,7 +143,7 @@ class Game:
             self.display_settings
         )
         # Ensure we have a default camera in case there are no others.
-        default_camera = Camera(
+        default_camera = BaseCamera(
             OrthoProjection(Rect(0, 0, *self.window.size)), enabled=False
         )
         CameraService._default_camera = default_camera

--- a/src/pyrite/sprite.py
+++ b/src/pyrite/sprite.py
@@ -1,6 +1,6 @@
 import pyrite._sprite.sprite
 import pyrite._sprite.spritesheet
 
-Sprite = pyrite._sprite.sprite.Sprite
+Sprite = pyrite._sprite.sprite.BaseSprite
 SpriteSheet = pyrite._sprite.spritesheet.SpriteSheet
 SpriteMap = pyrite._sprite.spritesheet.SpriteMap

--- a/src/pyrite/systems.py
+++ b/src/pyrite/systems.py
@@ -1,3 +1,3 @@
 import pyrite._systems.base_system
 
-System = pyrite._systems.base_system.BaseSystem
+BaseSystem = pyrite._systems.base_system.BaseSystem

--- a/src/pyrite/types.py
+++ b/src/pyrite/types.py
@@ -28,7 +28,7 @@ Projection = pyrite._types.projection.Projection
 Renderable = pyrite._types.renderable.Renderable
 Renderer = pyrite._types.renderer.Renderer
 RendererProvider = pyrite._types.renderer.RendererProvider
-Sprite = pyrite._types.sprite.BaseSprite
+Sprite = pyrite._types.sprite.Sprite
 System = pyrite._types.system.System
 CameraViewBounds = pyrite._types.view_bounds.CameraViewBounds
 

--- a/src/pyrite/types.py
+++ b/src/pyrite/types.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
     Point3D = SequenceLike[float]
 
 CullingBounds = pyrite._types.bounds.CullingBounds
-Camera = pyrite._types.camera.CameraBase
+Camera = pyrite._types.camera.Camera
 Component = pyrite._types.component.Component
 DebugRenderer = pyrite._types.debug_renderer.DebugRenderer
 Entity = pyrite._types.entity.Entity

--- a/tests/test_camera_service.py
+++ b/tests/test_camera_service.py
@@ -7,7 +7,7 @@ from pygame import Rect, Vector3
 from pyrite._services.camera_service import CameraServiceProvider as CameraService
 from pyrite.rendering import OrthoProjection
 from pyrite._types.projection import Projection
-from pyrite._types.camera import CameraBase
+from pyrite._types.camera import Camera
 from pyrite.transform import TransformComponent, Transform
 
 if TYPE_CHECKING:
@@ -28,14 +28,14 @@ zero_transform = Transform()
 
 class MockCamera:
 
-    def __new__(cls, *args, **kwds) -> CameraBase:
-        return cast(CameraBase, super().__new__(cls))
+    def __new__(cls, *args, **kwds) -> Camera:
+        return cast(Camera, super().__new__(cls))
 
     def __init__(self, projection: Projection) -> None:
         self.projection = projection
         self.transform: TransformComponent = TransformComponent(self)
         self.zoom_level: ZoomLevel = 1
-        CameraService.add_camera(cast(CameraBase, self))
+        CameraService.add_camera(cast(Camera, self))
 
 
 class TestCameraService(unittest.TestCase):

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -2,23 +2,23 @@ from __future__ import annotations
 import unittest
 from weakref import WeakKeyDictionary
 
-from pyrite.component import Component
+from pyrite.component import BaseComponent
 
 
-class ComponentA(Component):
+class ComponentA(BaseComponent):
 
     def foo(self):
         pass
 
 
-class ComponentB(Component):
+class ComponentB(BaseComponent):
 
     def bar(self):
         pass
 
 
-class ComponentC(Component):
-    component_data: dict[Component, str] = {}
+class ComponentC(BaseComponent):
+    component_data: dict[BaseComponent, str] = {}
 
     def __init__(self, owner, data: str = "") -> None:
         super().__init__(owner)
@@ -34,7 +34,7 @@ class ComponentC(Component):
         self.component_data[self] = data
 
     @classmethod
-    def _purge_component(cls, component: Component):
+    def _purge_component(cls, component: BaseComponent):
         # This will raise without a valid component
         cls.component_data.pop(component)
 
@@ -42,7 +42,7 @@ class ComponentC(Component):
 class TestOwner:
 
     def __init__(self, has_A: bool, has_B: bool, has_C: bool) -> None:
-        self.components: list[Component] = []
+        self.components: list[BaseComponent] = []
         if has_A:
             self.components.append(ComponentA(self))
         if has_B:

--- a/tests/test_entity_manager.py
+++ b/tests/test_entity_manager.py
@@ -5,13 +5,13 @@ from weakref import WeakSet
 import unittest
 
 from pyrite.core.entity_manager import DefaultEntityManager
-from pyrite.entity import Entity
+from pyrite.entity import BaseEntity
 
 
-class MockEntity(Entity):
+class MockEntity(BaseEntity):
 
-    def __new__(cls, *args, **kwds) -> Entity:
-        return cast(Entity, super().__new__(cls))
+    def __new__(cls, *args, **kwds) -> BaseEntity:
+        return cast(BaseEntity, super().__new__(cls))
 
     def __init__(self, game_instance=None, enabled=True) -> None:
         pass

--- a/tests/test_render_manager.py
+++ b/tests/test_render_manager.py
@@ -6,7 +6,7 @@ from weakref import WeakSet
 
 from pygame.rect import Rect as Rect
 
-from pyrite._camera.camera import Camera
+from pyrite._camera.camera import BaseCamera
 from pyrite.core.render_system import (
     DefaultRenderManager,
     _get_draw_index,
@@ -17,7 +17,7 @@ from pyrite.rendering import OrthoProjection, RectBounds
 from pyrite._rendering.base_renderable import BaseRenderable
 from pyrite._services.camera_service import CameraServiceProvider as CameraService
 from pyrite._types.bounds import CullingBounds
-from pyrite._types.camera import Camera as CameraBase
+from pyrite._types.camera import Camera
 from pyrite._types.renderable import Renderable
 
 
@@ -33,7 +33,7 @@ class MockRenderable(BaseRenderable):
         self._layer = layer
         self.draw_index = draw_index
 
-    def render(self, delta_time: float, camera: CameraBase):
+    def render(self, delta_time: float, camera: Camera):
         return super().render(delta_time, camera)
 
     def get_bounds(self) -> CullingBounds:
@@ -173,7 +173,7 @@ class TestDefaultRenderManager(unittest.TestCase):
         for renderable in all_elements:
             self.render_manager.enable(renderable)
 
-        default_camera = Camera(OrthoProjection((0, 0, 100, 100)))
+        default_camera = BaseCamera(OrthoProjection((0, 0, 100, 100)))
         CameraService._default_camera = default_camera
 
         render_queue = self.render_manager.generate_render_queue()

--- a/tests/test_render_manager.py
+++ b/tests/test_render_manager.py
@@ -17,7 +17,7 @@ from pyrite.rendering import OrthoProjection, RectBounds
 from pyrite._rendering.base_renderable import BaseRenderable
 from pyrite._services.camera_service import CameraServiceProvider as CameraService
 from pyrite._types.bounds import CullingBounds
-from pyrite._types.camera import CameraBase
+from pyrite._types.camera import Camera as CameraBase
 from pyrite._types.renderable import Renderable
 
 


### PR DESCRIPTION
Ensures that all base classes follow the naming convention, where the type name is unappended, and the base class is appended with `Base`

Example:

type: `Foo`
base: `BaseFoo`

This encourages splitting between the type, used for type checking, and the base class that holds any common code for its descendants.