### PR TITLE
Delta time overhaul

### DIFF
--- a/src/pyrite/_camera/camera.py
+++ b/src/pyrite/_camera/camera.py
@@ -136,8 +136,8 @@ class BaseCamera(Camera):
     def get_viewports(self) -> list[Viewport]:
         return self._viewports
 
-    def render(self, delta_time: float, render_target: RenderTarget):
-        CameraRenderer.render(delta_time, self, render_target)
+    def render(self, render_target: RenderTarget):
+        CameraRenderer.render(self, render_target)
 
     def to_local(self, point: Transform) -> Transform:
         return CameraService.to_local(self, point)

--- a/src/pyrite/_entity/entity.py
+++ b/src/pyrite/_entity/entity.py
@@ -63,7 +63,7 @@ class BaseEntity(Entity):
     def post_update(self) -> None:
         pass
 
-    def const_update(self, timestep: float) -> None:
+    def const_update(self) -> None:
         pass
 
     def on_event(self, event: Event):

--- a/src/pyrite/_entity/entity.py
+++ b/src/pyrite/_entity/entity.py
@@ -54,13 +54,13 @@ class BaseEntity(Entity):
     def on_disable(self):
         pass
 
-    def pre_update(self, delta_time: float) -> None:
+    def pre_update(self) -> None:
         pass
 
-    def update(self, delta_time: float) -> None:
+    def update(self) -> None:
         pass
 
-    def post_update(self, delta_time: float) -> None:
+    def post_update(self) -> None:
         pass
 
     def const_update(self, timestep: float) -> None:

--- a/src/pyrite/_entity/entity_chaser.py
+++ b/src/pyrite/_entity/entity_chaser.py
@@ -7,6 +7,7 @@ from pygame import Vector2
 
 from pyrite._component.transform_component import TransformComponent
 from pyrite._entity.entity import BaseEntity
+import pyrite.time
 
 if TYPE_CHECKING:
     from pyrite._types.protocols import (
@@ -71,24 +72,23 @@ class EntityChaser(BaseEntity):
 
         self.dist_function = dist_function
 
-    def post_update(self, delta_time: float) -> None:
+    def post_update(self) -> None:
         if not self.target:
             return
         delta = self.calculate_ease(
-            self.transform.world_position - self.target.transform.world_position,
-            delta_time,
+            self.transform.world_position - self.target.transform.world_position
         )
         if self.max_distance >= 0:
             delta = self.clamp_magnitude(delta)
         self.transform.world_position = self.target.transform.world_position + delta
 
-    def calculate_ease(self, delta: Vector2, delta_time: float) -> Vector2:
+    def calculate_ease(self, delta: Vector2) -> Vector2:
         distance = delta.magnitude()
         if distance == 0:
             return delta
         delta_normalized = delta.normalize()
         distance_adjustment = distance / self.ease_factor
-        distance_adjustment *= 60 * delta_time
+        distance_adjustment *= 60 * pyrite.time.delta_time()
         distance -= distance_adjustment
 
         return delta_normalized * distance

--- a/src/pyrite/_rendering/camera_renderer/__init__.py
+++ b/src/pyrite/_rendering/camera_renderer/__init__.py
@@ -22,8 +22,8 @@ class CameraRendererProvider(RendererProvider[CameraRenderer]):
         cls._renderer = renderer
 
     @classmethod
-    def render(cls, delta_time: float, renderable: Camera, target: RenderTarget):
-        cls._renderer.render(delta_time, renderable, target)
+    def render(cls, renderable: Camera, target: RenderTarget):
+        cls._renderer.render(renderable, target)
 
     @classmethod
     def get_smooth_scale(cls) -> bool:

--- a/src/pyrite/_rendering/camera_renderer/camera_renderer.py
+++ b/src/pyrite/_rendering/camera_renderer/camera_renderer.py
@@ -43,7 +43,7 @@ class DefaultCameraRenderer(CameraRenderer):
         else:
             self.scale_method = pygame.transform.scale
 
-    def render(self, delta_time: float, renderable: Camera, target: RenderTarget):
+    def render(self, renderable: Camera, target: RenderTarget):
         surface = target.get_target_surface()
         render_rect = target.get_target_rect()
         camera_service = cast(

--- a/src/pyrite/_rendering/sprite_renderer/__init__.py
+++ b/src/pyrite/_rendering/sprite_renderer/__init__.py
@@ -23,8 +23,8 @@ class SpriteRendererProvider(RendererProvider[SpriteRenderer]):
     _renderer: SpriteRenderer = DefaultSpriteRenderer()
 
     @classmethod
-    def render(cls, delta_time: float, sprite: Sprite, camera: Camera):
-        cls._renderer.render(delta_time, sprite, camera)
+    def render(cls, sprite: Sprite, camera: Camera):
+        cls._renderer.render(sprite, camera)
 
     @classmethod
     def validate_sprite(

--- a/src/pyrite/_rendering/sprite_renderer/sprite_renderer.py
+++ b/src/pyrite/_rendering/sprite_renderer/sprite_renderer.py
@@ -70,7 +70,7 @@ class DefaultSpriteRenderer(SpriteRenderer):
     def get(self, key: Sprite) -> SpriteData | tuple[None, None]:
         return self._sprite_cache.get(key, (None, None))
 
-    def render(self, delta_time: float, renderable: Sprite, target: Camera):
+    def render(self, renderable: Sprite, target: Camera):
         surface, transform = self.get(renderable)
         if surface is None or not self.validate_sprite(renderable, surface, transform):
             # Update the cache. This will save us redraws when the sprite is unchanged.

--- a/src/pyrite/_sprite/sprite.py
+++ b/src/pyrite/_sprite/sprite.py
@@ -181,5 +181,5 @@ class BaseSprite(Sprite, Renderable):
 
         return bounds
 
-    def render(self, delta_time: float, camera: Camera):
-        SpriteRenderer.render(delta_time, self, camera)
+    def render(self, camera: Camera):
+        SpriteRenderer.render(self, camera)

--- a/src/pyrite/_systems/physics_system.py
+++ b/src/pyrite/_systems/physics_system.py
@@ -8,6 +8,7 @@ from pyrite._services.physics_service import PhysicsServiceProvider as PhysicsSe
 from pyrite._services.transform_service import (
     TransformServiceProvider as TransformService,
 )
+import pyrite.time
 
 
 if TYPE_CHECKING:
@@ -26,13 +27,13 @@ class PhysicsSystem(BaseSystem):
         super().__init__(enabled, order_index)
         self.physics_mult = physics_mult
 
-    def const_update(self, timestep: float) -> None:
+    def const_update(self) -> None:
         # Ensure that the rigidbodies are where we want them to be.
         # If multiple constupdates are happening, this might cause issues.
         # TODO: Move this elsewhere so that it only happens once per frame?
         PhysicsService.sync_bodies_to_transforms()
 
-        PhysicsService.step(timestep * self.physics_mult)
+        PhysicsService.step(pyrite.time.fixed_time_step() * self.physics_mult)
 
     def update(self) -> None:
         self.sync_transforms_to_bodies()

--- a/src/pyrite/_systems/physics_system.py
+++ b/src/pyrite/_systems/physics_system.py
@@ -34,7 +34,7 @@ class PhysicsSystem(BaseSystem):
 
         PhysicsService.step(timestep * self.physics_mult)
 
-    def update(self, delta_time: float) -> None:
+    def update(self) -> None:
         self.sync_transforms_to_bodies()
 
     def sync_transforms_to_bodies(self):

--- a/src/pyrite/_systems/transform_system.py
+++ b/src/pyrite/_systems/transform_system.py
@@ -18,7 +18,7 @@ class TransformSystem(BaseSystem):
     rendering.
     """
 
-    def pre_render(self, delta_time: float) -> None:
+    def pre_render(self) -> None:
         TransformService.frame_reset()
         for component in TransformService.traverse_transforms():
             assert component

--- a/src/pyrite/_types/camera.py
+++ b/src/pyrite/_types/camera.py
@@ -82,11 +82,10 @@ class Camera(ABC):
         pass
 
     @abstractmethod
-    def render(self, delta_time: float, render_target: RenderTarget):
+    def render(self, render_target: RenderTarget):
         """
         Renders the camera view to the render target
 
-        :param delta_time: Time passed since last frame, in seconds.
         :param render_target: _description_
         """
         pass

--- a/src/pyrite/_types/entity.py
+++ b/src/pyrite/_types/entity.py
@@ -93,7 +93,7 @@ class Entity(ABC):
         ...
 
     @abstractmethod
-    def const_update(self, timestep: float) -> None:
+    def const_update(self) -> None:
         """
         A method that is called during the const_update phase.
         Useful for behavior that is sensitive to time fluctuations,
@@ -103,8 +103,6 @@ class Entity(ABC):
 
         const_update may be called any number of times per frame,
         depending on timestep length.
-
-        :param timestep: Length of the timestep being simulated.
         """
         ...
 

--- a/src/pyrite/_types/entity.py
+++ b/src/pyrite/_types/entity.py
@@ -69,32 +69,26 @@ class Entity(ABC):
         ...
 
     @abstractmethod
-    def pre_update(self, delta_time: float) -> None:
+    def pre_update(self) -> None:
         """
         A method that is called during the pre_update phase.
         Will always be called before update.
-
-        :param delta_time: Time passed since last frame.
         """
         ...
 
     @abstractmethod
-    def update(self, delta_time: float) -> None:
+    def update(self) -> None:
         """
         A method that is called during the main update phase.
         Most behaviour should happen here.
-
-        :param delta_time: Time passed since last frame.
         """
         ...
 
     @abstractmethod
-    def post_update(self, delta_time: float) -> None:
+    def post_update(self) -> None:
         """
         A method that is called during the post_update phase.
         Will always be called after update.
-
-        :param delta_time: Time passed since last frame.
         """
         ...
 

--- a/src/pyrite/_types/protocols.py
+++ b/src/pyrite/_types/protocols.py
@@ -47,17 +47,17 @@ class HasTexture(Protocol):
 
 class CanUpdate(Protocol):
 
-    def update(self, delta_time: float) -> None: ...
+    def update(self) -> None: ...
 
 
 class CanPreUpdate(Protocol):
 
-    def pre_update(self, delta_time: float) -> None: ...
+    def pre_update(self) -> None: ...
 
 
 class CanPostUpdate(Protocol):
 
-    def post_update(self, delta_time: float) -> None: ...
+    def post_update(self) -> None: ...
 
 
 class CanConstUpdate(Protocol):

--- a/src/pyrite/_types/protocols.py
+++ b/src/pyrite/_types/protocols.py
@@ -62,7 +62,7 @@ class CanPostUpdate(Protocol):
 
 class CanConstUpdate(Protocol):
 
-    def const_update(self, timestep: float) -> None: ...
+    def const_update(self) -> None: ...
 
 
 class RenderTarget(Protocol):

--- a/src/pyrite/_types/renderable.py
+++ b/src/pyrite/_types/renderable.py
@@ -85,13 +85,11 @@ class Renderable(ABC):
         pass
 
     @abstractmethod
-    def render(self, delta_time: float, camera: Camera):
+    def render(self, camera: Camera):
         """
         Causes the Renderable to be rendered to the given camera. Typically calls upon
         some renderer class that knows how to handle its data.
 
-        :param delta_time: Time passed since last frame. Can be ignored by the concrete
-            method but must be accepted.
         :param camera: A camera-type object to be drawn to.
         """
         pass

--- a/src/pyrite/_types/renderer.py
+++ b/src/pyrite/_types/renderer.py
@@ -10,13 +10,10 @@ if TYPE_CHECKING:
 class Renderer[RenderableTypeT, RenderTargetT](ABC):
 
     @abstractmethod
-    def render(
-        self, delta_time: float, renderable: RenderableTypeT, target: RenderTargetT
-    ):
+    def render(self, renderable: RenderableTypeT, target: RenderTargetT):
         """
         Draws the renderable to the screen.
 
-        :param delta_time: Time passed since last frame
         :param renderable: The renderable item, of the type handled by the renderer.
         :param target: An object to render to.
         """

--- a/src/pyrite/_types/system.py
+++ b/src/pyrite/_types/system.py
@@ -50,7 +50,7 @@ class System(ABC):
         """
         pass
 
-    def const_update(self, timestep: float) -> None:
+    def const_update(self) -> None:
         """
         A method that is called during the const_update phase.
         Useful for behavior that is sensitive to time fluctuations,
@@ -60,8 +60,6 @@ class System(ABC):
 
         const_update may be called any number of times per frame,
         depending on timestep length.
-
-        :param timestep: Length of the timestep being simulated.
         """
         pass
 

--- a/src/pyrite/_types/system.py
+++ b/src/pyrite/_types/system.py
@@ -29,30 +29,24 @@ class System(ABC):
     def enabled(self, enabled: bool):
         pass
 
-    def pre_update(self, delta_time: float) -> None:
+    def pre_update(self) -> None:
         """
         A method that is called during the pre_update phase.
         Will always be called before update.
-
-        :param delta_time: Time passed since last frame.
         """
         pass
 
-    def update(self, delta_time: float) -> None:
+    def update(self) -> None:
         """
         A method that is called during the main update phase.
         Most behaviour should happen here.
-
-        :param delta_time: Time passed since last frame.
         """
         pass
 
-    def post_update(self, delta_time: float) -> None:
+    def post_update(self) -> None:
         """
         A method that is called during the post_update phase.
         Will always be called after update.
-
-        :param delta_time: Time passed since last frame.
         """
         pass
 
@@ -71,13 +65,11 @@ class System(ABC):
         """
         pass
 
-    def pre_render(self, delta_time: float) -> None:
+    def pre_render(self) -> None:
         """
         A method that is called immediately before the render phase.
         Used by TransformServices to ensure transforms are properly updated just prior
         to being used to display them.
-
-        :param delta_time: Time passed since last frame.
         """
 
     def on_event(self, event: Event):

--- a/src/pyrite/core/entity_manager.py
+++ b/src/pyrite/core/entity_manager.py
@@ -150,11 +150,9 @@ class EntityManager(ABC):
         pass
 
     @abstractmethod
-    def const_update(self, timestep: float):
+    def const_update(self):
         """
         Runs the const_update phase for active entities.
-
-        :param timestep: Length of the simulated step
         """
         pass
 
@@ -238,9 +236,9 @@ class DefaultEntityManager(EntityManager):
         for entity in self.entities:
             entity.post_update()
 
-    def const_update(self, timestep: float):
+    def const_update(self):
         for entity in self.entities:
-            entity.const_update(timestep)
+            entity.const_update()
 
     def handle_event(self, event: pygame.Event):
         for entity in self.entities:

--- a/src/pyrite/core/entity_manager.py
+++ b/src/pyrite/core/entity_manager.py
@@ -129,29 +129,23 @@ class EntityManager(ABC):
     # Update Methods
 
     @abstractmethod
-    def pre_update(self, delta_time: float):
+    def pre_update(self):
         """
         Runs the pre_update phase for active entities.
-
-        :param delta_time: Time passed since last frame
         """
         pass
 
     @abstractmethod
-    def update(self, delta_time: float):
+    def update(self):
         """
         Runs the update phase for active entities.
-
-        :param delta_time: Time passed since last frame
         """
         pass
 
     @abstractmethod
-    def post_update(self, delta_time: float):
+    def post_update(self):
         """
         Runs the post_update phase for active entities.
-
-        :param delta_time: Time passed since last frame
         """
         pass
 
@@ -232,17 +226,17 @@ class DefaultEntityManager(EntityManager):
         self._added_buffer = set()
         self._disabled_buffer = set()
 
-    def pre_update(self, delta_time: float):
+    def pre_update(self):
         for entity in self.entities:
-            entity.pre_update(delta_time)
+            entity.pre_update()
 
-    def update(self, delta_time: float):
+    def update(self):
         for entity in self.entities:
-            entity.update(delta_time)
+            entity.update()
 
-    def post_update(self, delta_time: float):
+    def post_update(self):
         for entity in self.entities:
-            entity.post_update(delta_time)
+            entity.post_update()
 
     def const_update(self, timestep: float):
         for entity in self.entities:

--- a/src/pyrite/core/rate_settings.py
+++ b/src/pyrite/core/rate_settings.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import logging
 import typing
 
+import pyrite.time
+
 logger = logging.getLogger(__name__)
 
 MAX_TICK_RATE_WARNING = 120.0
@@ -45,6 +47,8 @@ class RateSettings:
         # Setting fixed timestep to -1 if timestep is 0 in case it gets referenced
         # without checking tickrate.
         self._fixed_timestep: float = 1 / tick_rate if tick_rate > 0 else -1
+
+        self._set_fixed_time_step(self._fixed_timestep)
 
     @property
     def fps_cap(self) -> int:
@@ -92,6 +96,8 @@ class RateSettings:
             self._fixed_timestep = -1
             logger.info("Tick rate set to '0'. 'const_update' is disabled.")
 
+        self._set_fixed_time_step(self._fixed_timestep)
+
     @property
     def fixed_timestep(self) -> float:
         """
@@ -111,6 +117,12 @@ class RateSettings:
             raise ValueError("Timestep must be greater than zero.")
         self._fixed_timestep = fixed_timestep
         self._tick_rate = 1 / fixed_timestep
+
+        self._set_fixed_time_step(self._fixed_timestep)
+
+    @staticmethod
+    def _set_fixed_time_step(timestep: float) -> None:
+        pyrite.time._fxt = timestep
 
     @staticmethod
     def get_rate_settings(**kwds) -> RateSettings:

--- a/src/pyrite/core/render_system.py
+++ b/src/pyrite/core/render_system.py
@@ -185,7 +185,6 @@ class RenderSystem(ABC):
     def render(
         self,
         window: Surface,
-        delta_time: float,
         render_queue: RenderQueue,
     ):
         """
@@ -338,7 +337,6 @@ class DefaultRenderSystem(RenderSystem):
 
     def render_layer(
         self,
-        delta_time: float,
         layer_queue: Iterable[Renderable],
         camera: Camera,
     ):
@@ -346,34 +344,30 @@ class DefaultRenderSystem(RenderSystem):
         Extracts the renderables from the layer_queue, and has them drawn to the
         camera.
 
-        :param delta_time: Time passed since last frame.
         :param layer_queue: The ordered sequence of renderables to be drawn.
         :param camera: The camera being drawn to.
         """
         count = 0
         for renderable in layer_queue:
             count += 1
-            renderable.render(delta_time, camera)
+            renderable.render(camera)
         self._rendered_last_frame += count
 
     def render_camera(
         self,
-        delta_time: float,
         camera: Camera,
     ):
         """
         Draws the given camera to the window, at each of its surface viewports.
 
-        :param delta_time: Time passed since last frame, if needed for any calculations.
         :param camera: Camera being drawn to the screen
         :param window: Game window being drawn to
         """
         for render_target in camera.render_targets:
-            camera.render(delta_time, render_target)
+            camera.render(render_target)
 
     def render_ui(
         self,
-        delta_time: float,
         ui_elements: Iterable[Renderable],
         window: Surface,
     ):
@@ -381,17 +375,15 @@ class DefaultRenderSystem(RenderSystem):
         Goes through the ui elements, and draws them to the screen. They are already in
         screen space, so they do not get adjusted.
 
-        :param delta_time: Time passed since last frame.
         :param ui_elements: The sequence of ui elements to be drawn, in order.
         :param cameras: The cameras being drawn to.
         """
         # for ui_element in ui_elements:
-        #     ui_element.render(delta_time, window)
+        #     ui_element.render(window)
 
     def render(
         self,
         window: Surface,
-        delta_time: float,
         render_queue: RenderQueue,
     ):
         self._rendered_last_frame = 0
@@ -408,11 +400,11 @@ class DefaultRenderSystem(RenderSystem):
             for camera, render_sequence in layer_dict.items():
                 if layer in camera.layer_mask:
                     continue
-                self.render_layer(delta_time, render_sequence, camera)
+                self.render_layer(render_sequence, camera)
 
         # Render any cameras to the screen.
         for camera in CameraService.get_active_cameras():
-            self.render_camera(delta_time, camera)
+            self.render_camera(camera)
 
         self._debug_draw_to_screen(cameras, render_queue)
 

--- a/src/pyrite/core/system_manager.py
+++ b/src/pyrite/core/system_manager.py
@@ -157,11 +157,9 @@ class SystemManager(ABC):
         pass
 
     @abstractmethod
-    def const_update(self, timestep: float):
+    def const_update(self):
         """
         Runs the const_update phase for active systems.
-
-        :param timestep: Length of the simulated step
         """
         pass
 
@@ -255,9 +253,9 @@ class DefaultSystemManager(SystemManager):
         for system in self.current_systems:
             system.post_update()
 
-    def const_update(self, timestep: float):
+    def const_update(self):
         for system in self.current_systems:
-            system.const_update(timestep)
+            system.const_update()
 
     def pre_render(self):
         for system in self.current_systems:

--- a/src/pyrite/core/system_manager.py
+++ b/src/pyrite/core/system_manager.py
@@ -136,29 +136,23 @@ class SystemManager(ABC):
         pass
 
     @abstractmethod
-    def pre_update(self, delta_time: float):
+    def pre_update(self):
         """
         Runs the pre_update phase for active systems.
-
-        :param delta_time: Time passed since last frame
         """
         pass
 
     @abstractmethod
-    def update(self, delta_time: float):
+    def update(self):
         """
         Runs the update phase for active systems.
-
-        :param delta_time: Time passed since last frame
         """
         pass
 
     @abstractmethod
-    def post_update(self, delta_time: float):
+    def post_update(self):
         """
         Runs the post_update phase for active systems.
-
-        :param delta_time: Time passed since last frame
         """
         pass
 
@@ -172,11 +166,9 @@ class SystemManager(ABC):
         pass
 
     @abstractmethod
-    def pre_render(self, delta_time: float):
+    def pre_render(self):
         """
         Runs the pre_render phase for active systems.
-
-        :param delta_time: Time passed since last frame
         """
 
     @abstractmethod
@@ -251,25 +243,25 @@ class DefaultSystemManager(SystemManager):
     def prepare_systems(self):
         self.current_systems = self.sort_systems(self.active_systems)
 
-    def pre_update(self, delta_time: float):
+    def pre_update(self):
         for system in self.current_systems:
-            system.pre_update(delta_time)
+            system.pre_update()
 
-    def update(self, delta_time: float):
+    def update(self):
         for system in self.current_systems:
-            system.update(delta_time)
+            system.update()
 
-    def post_update(self, delta_time: float):
+    def post_update(self):
         for system in self.current_systems:
-            system.post_update(delta_time)
+            system.post_update()
 
     def const_update(self, timestep: float):
         for system in self.current_systems:
             system.const_update(timestep)
 
-    def pre_render(self, delta_time: float):
+    def pre_render(self):
         for system in self.current_systems:
-            system.pre_render(delta_time)
+            system.pre_render()
 
     def handle_event(self, event: Event):
         for system in self.current_systems:

--- a/src/pyrite/game.py
+++ b/src/pyrite/game.py
@@ -212,12 +212,12 @@ class Game:
                 self.rate_settings.fixed_timestep, accumulated_time
             )
 
-        self._update_block(delta_time)
+        self._update_block()
 
         if not (caption := self.game_data.caption):
             caption = self.game_data.title
         pygame.display.set_caption(caption)
-        self._render_block(self.window, delta_time)
+        self._render_block(self.window)
 
         return accumulated_time
 
@@ -236,30 +236,24 @@ class Game:
         accumulated_time += delta_time
         return (delta_time, accumulated_time)
 
-    def pre_update(self, delta_time: float) -> None:
+    def pre_update(self) -> None:
         """
         Early update function. Used for game logic that needs to run _before_ the main
         update phase.
-
-        :param delta_time: Actual time passed since last frame, in seconds.
         """
         pass
 
-    def update(self, delta_time: float) -> None:
+    def update(self) -> None:
         """
         Main update function. Used for coordinating most of the game state changes
-        required.
-
-        :param delta_time: Actual time passed since last frame, in seconds.
+        required..
         """
         pass
 
-    def post_update(self, delta_time: float) -> None:
+    def post_update(self) -> None:
         """
         Late update function. Used for game logic that needs to run _after_ the main
         update phase.
-
-        :param delta_time: Actual time passed since last frame, in seconds.
         """
         pass
 
@@ -279,20 +273,18 @@ class Game:
         """
         pass
 
-    def _update_block(self, delta_time: float) -> None:
+    def _update_block(self) -> None:
         """
         Calls all of the update phases, in order.
-
-        :param delta_time: Actual time passed since last frame, in seconds.
         """
 
-        self.pre_update(delta_time)
+        self.pre_update()
         self.system_manager.pre_update()
         self.entity_manager.pre_update()
-        self.update(delta_time)
+        self.update()
         self.system_manager.update()
         self.entity_manager.update()
-        self.post_update(delta_time)
+        self.post_update()
         self.system_manager.post_update()
         self.entity_manager.post_update()
 
@@ -317,21 +309,19 @@ class Game:
             accumulated_time -= timestep
         return accumulated_time
 
-    def render(self, window: pygame.Surface, delta_time: float) -> None:
+    def render(self, window: pygame.Surface) -> None:
         """
         Main drawing phase. Used for rendering active game objects to the screen.
 
         :param window: The main display window.
-        :param delta_time: Time passed since last frame, in seconds.
         """
         pass
 
-    def _render_block(self, window: pygame.Surface, delta_time: float) -> None:
+    def _render_block(self, window: pygame.Surface) -> None:
         """
         Calls the render functions, and updates the display.
 
         :param window: The main display window.
-        :param delta_time: Time passed since last frame, in seconds.
         """
         # Finalize any systems
         self.system_manager.pre_render()
@@ -342,7 +332,7 @@ class Game:
         render_queue = self.render_manager.generate_render_queue()
         self.renderer.render(self.window, render_queue)
 
-        self.render(window, delta_time)
+        self.render(window)
 
         pygame.display.flip()
 

--- a/src/pyrite/game.py
+++ b/src/pyrite/game.py
@@ -257,7 +257,7 @@ class Game:
         """
         pass
 
-    def const_update(self, timestep: float) -> None:
+    def const_update(self) -> None:
         """
         Update function that runs at a constant rate. Useful for anything that is
         sensitive to variations in frame time, such as physics.
@@ -267,9 +267,6 @@ class Game:
         eachother.
 
         For more info, see Glenn Fiedler's "Fix Your Timestep!"
-
-        :param timestep: Simulated time passed since last update. Passed in from the
-        game's rate_settings.
         """
         pass
 
@@ -303,9 +300,9 @@ class Game:
         :return: Remaining accumulated time.
         """
         while accumulated_time > timestep:
-            self.const_update(timestep)
-            self.system_manager.const_update(timestep)
-            self.entity_manager.const_update(timestep)
+            self.const_update()
+            self.system_manager.const_update()
+            self.entity_manager.const_update()
             accumulated_time -= timestep
         return accumulated_time
 

--- a/src/pyrite/game.py
+++ b/src/pyrite/game.py
@@ -288,13 +288,13 @@ class Game:
 
         self.pre_update(delta_time)
         self.system_manager.pre_update()
-        self.entity_manager.pre_update(delta_time)
+        self.entity_manager.pre_update()
         self.update(delta_time)
         self.system_manager.update()
-        self.entity_manager.update(delta_time)
+        self.entity_manager.update()
         self.post_update(delta_time)
         self.system_manager.post_update()
-        self.entity_manager.post_update(delta_time)
+        self.entity_manager.post_update()
 
     def _fixed_update_block(self, timestep: float, accumulated_time: float) -> float:
         """

--- a/src/pyrite/game.py
+++ b/src/pyrite/game.py
@@ -287,13 +287,13 @@ class Game:
         """
 
         self.pre_update(delta_time)
-        self.system_manager.pre_update(delta_time)
+        self.system_manager.pre_update()
         self.entity_manager.pre_update(delta_time)
         self.update(delta_time)
-        self.system_manager.update(delta_time)
+        self.system_manager.update()
         self.entity_manager.update(delta_time)
         self.post_update(delta_time)
-        self.system_manager.post_update(delta_time)
+        self.system_manager.post_update()
         self.entity_manager.post_update(delta_time)
 
     def _fixed_update_block(self, timestep: float, accumulated_time: float) -> float:
@@ -334,7 +334,7 @@ class Game:
         :param delta_time: Time passed since last frame, in seconds.
         """
         # Finalize any systems
-        self.system_manager.pre_render(delta_time)
+        self.system_manager.pre_render()
 
         # Redundant if no cameras, but cameras could cause this to be needed.
         window.fill(pygame.Color("black"))  # TODO Make this changeable

--- a/src/pyrite/game.py
+++ b/src/pyrite/game.py
@@ -19,6 +19,7 @@ from pyrite._rendering.viewport import Viewport
 from pyrite._services.camera_service import CameraServiceProvider as CameraService
 from pyrite._systems import transform_system
 from pyrite.utils import threading
+import pyrite.time
 
 if TYPE_CHECKING:
     from types import TracebackType
@@ -197,6 +198,8 @@ class Game:
         delta_time, accumulated_time = self._get_frame_time(
             self.rate_settings.fps_cap, accumulated_time
         )
+
+        pyrite.time._dt = delta_time
 
         # This will ensure new entities are processed properly for the new frame.
         self.entity_manager.flush_buffer()

--- a/src/pyrite/game.py
+++ b/src/pyrite/game.py
@@ -340,7 +340,7 @@ class Game:
         window.fill(pygame.Color("black"))  # TODO Make this changeable
 
         render_queue = self.render_manager.generate_render_queue()
-        self.renderer.render(self.window, delta_time, render_queue)
+        self.renderer.render(self.window, render_queue)
 
         self.render(window, delta_time)
 

--- a/src/pyrite/time.py
+++ b/src/pyrite/time.py
@@ -1,0 +1,8 @@
+_dt: float = 0
+
+
+def delta_time() -> float:
+    """
+    Returns the time passed since the previous frame.
+    """
+    return _dt

--- a/src/pyrite/time.py
+++ b/src/pyrite/time.py
@@ -1,4 +1,5 @@
 _dt: float = 0
+_fxt: float = 0
 
 
 def delta_time() -> float:
@@ -6,3 +7,10 @@ def delta_time() -> float:
     Returns the time passed since the previous frame.
     """
     return _dt
+
+
+def fixed_time_step() -> float:
+    """
+    Returns the length of the fixed time step used in const_update.
+    """
+    return _fxt

--- a/tests/test_render_manager.py
+++ b/tests/test_render_manager.py
@@ -34,8 +34,8 @@ class MockRenderable(BaseRenderable):
         self._layer = layer
         self.draw_index = draw_index
 
-    def render(self, delta_time: float, camera: Camera):
-        return super().render(delta_time, camera)
+    def render(self, camera: Camera):
+        return super().render(camera)
 
     def get_bounds(self) -> CullingBounds:
         return RectBounds(Rect(-1024, -1024, 2048, 2048))


### PR DESCRIPTION
Removes all passing of delta time and the fixed time step through parameters.

Now, delta time and timestep can be accessed through the pyrite.time module, via the `delta_time()` and `fixed_time_step()` functions. This allows them to be accessible everywhere, without needing to pass the values around, and means that unused parameters do not need to be included in derived entities and systems.